### PR TITLE
Fix explanation and remove unwanted behaviour in hello-bdi tutorial

### DIFF
--- a/doc/tutorials/hello-bdi/code/Calendar.java
+++ b/doc/tutorials/hello-bdi/code/Calendar.java
@@ -8,7 +8,6 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JSlider;
 import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 
 import cartago.INTERNAL_OPERATION;
 import cartago.ObsProperty;
@@ -24,7 +23,6 @@ public class Calendar extends GUIArtifact {
                 ASSyntax.createAtom("friday"),
                 ASSyntax.createAtom("saturday")
             };
-
 
     public void setup() {
         defineObsProperty("today", days[0]);
@@ -57,19 +55,16 @@ public class Calendar extends GUIArtifact {
         f.setVisible(true);
     }
 
-    /*
-    protected void linkChangeEventToOp(JSlider source, String opName){
-        insertEventToOp(source,"stateChanged",opName);
-        source.addChangeListener((ChangeListener) getEventListenerInstance());
-    }
-    */
-
-    @INTERNAL_OPERATION void updateDay(ChangeEvent ev) {
-        try {
-            ObsProperty prop = getObsProperty("today");
-            prop.updateValue(days[ (int)s.getValue() ]);
-        } catch (Exception e2) {
-            e2.printStackTrace();
+    @INTERNAL_OPERATION
+    void updateDay(ChangeEvent ev) {
+        JSlider source = (JSlider) ev.getSource();
+        if (!source.getValueIsAdjusting()) {
+            try {
+                ObsProperty prop = getObsProperty("today");
+                prop.updateValue(days[(int) s.getValue()]);
+            } catch (Exception e2) {
+                e2.printStackTrace();
+            }
         }
     }
 }

--- a/doc/tutorials/hello-bdi/readme.adoc
+++ b/doc/tutorials/hello-bdi/readme.adoc
@@ -315,11 +315,11 @@ of `happy(H)` is sincere
 (http://jason.sourceforge.net/api/jason/stdlib/my_name.html[`.my_name`]
 is true if the value of `H` is the name of the agent executing that
 internal action). The second plan is used otherwise. The first plan for
-`+!say(X)` is used in days other than Monday and the second on Fridays.
+`+!say(X)` is used on Fridays and the second on days other than Monday.
 (Notice that there is a plan for Mondays that does not actually say anything
 but just keeps the intention alive. Without it Bob would find no plan for
-`say(X)` on Monday and the intention for `say(X)` would not be re-added. Bob
-would have to remain mute ever after.)
+`say(X)` on Monday and the intention for `say(X)` would not be re-added. Thus, Bob
+would remain mute thereafter.)
 
 Instead of using REPL, we will add a new agent, called Alice, to run
 this system:


### PR DESCRIPTION
There were some problems with the explanation of the given code for the vigilant Bob. The sentence  

> The first plan for +!say(X) is used in days other than Monday and the second on Fridays. 

is actually wrong for two reasons. First, it should be _on days_ instead of _in days_. Second, the first plan is actually for Fridays and the second for days other than Monday.
The last sentence was also modified as it was wrong in a way and also not well connected with the previous one.

Another problem I found and fixed was that there were three belief additions every time I moved the slider knob of the Calendar artefact. The problem is that, by default, there are 3 events as part of the chain in a ChangeListener, namely mouseDown, mouseUp and the change itself. As the program
is only interested in the final result, the artifact should be updated only when the action has finished.