### PR TITLE
Create agent while in debug mode

### DIFF
--- a/src/main/java/jason/infra/centralised/CentralisedRuntimeServices.java
+++ b/src/main/java/jason/infra/centralised/CentralisedRuntimeServices.java
@@ -58,6 +58,16 @@ public class CentralisedRuntimeServices implements RuntimeServicesInfraTier {
             agArch.createArchs(ap.getAgArchClasses(), ap.agClass.getClassName(), ap.getBBClass(), agSource, stts, masRunner);
             agArch.setEnvInfraTier(masRunner.getEnvironmentInfraTier());
             agArch.setControlInfraTier(masRunner.getControllerInfraTier());
+            
+            // if debug mode is active, set up new agent to be synchronous and visible for ExecutionControlGUI
+            if(BaseCentralisedMAS.debug) {
+                stts.setVerbose(2);
+                stts.setSync(true);
+                agArch.getLogger().setLevel(Level.FINE);
+                agArch.getTS().getLogger().setLevel(Level.FINE);
+                agArch.getTS().getAg().getLogger().setLevel(Level.FINE);
+            } 
+
             masRunner.addAg(agArch);
         }
 


### PR DESCRIPTION
Currently, while the system is in debug mode (e.g. started with the `"-debug"` parameter), agents that are  created on the fly using the `CentralisedRuntimeServices#createAgent` method are not configured for debug mode. Especially, they are not visible in the left-hand pane of the debug GUI (`ExecutionControlGUI`) and not operating in synchronous mode.

I propose a fix, which checks whether debug mode is enabled during execution of the `createAgent` method, and if yes sets up the agent in the same way that `RunCentralisedMAS#changeToDebugMode` uses. In particular: 

- line 65 `stts.setSync(true);` enables the agent's reasoning cycle to await the manual Run command by the user, 
- lines 66-68 set the agent's logging level to an appropriate granularity,
- line 64: `stts.setVerbose(2);` makes the new agent appear in the left-hand pane of the debug GUI ("Agents"), and by that makes it debuggable. As far as I understand, such an update can happen only if the name of the new agent is added to `ExecutionControlGUI.listModel`. However, I am not sure why setting verbose to 2 has this particular effect.  ;)