### PR TITLE
Check for operating system in IDE script

### DIFF
--- a/scripts/jason-ide
+++ b/scripts/jason-ide
@@ -4,7 +4,20 @@ source "`dirname "$0"`/jason-setup"
 
 JEDIT_HOME=$JASON_HOME/jedit
 
+systemName="$(uname -s)"
+case "${systemName}" in
+    CYGWIN*)    os=win;;
+    MINGW*)     os=win;;
+    *)          os=nix
+esac
+
+if [ ${os} == "win" ]; then
+  CP="$JASON_JAR;$JEDIT_HOME/jedit.jar;$JEDIT_HOME/jars/ErrorList.jar;$JEDIT_HOME/jars/SideKick.jar;$JADE_JAR"
+else
+  CP="$JASON_JAR:$JEDIT_HOME/jedit.jar:$JEDIT_HOME/jars/ErrorList.jar:$JEDIT_HOME/jars/SideKick.jar:$JADE_JAR"
+fi
+
 # run jIDE
 java \
--classpath "$JASON_JAR":"$JEDIT_HOME/jedit.jar":"$JEDIT_HOME/jars/ErrorList.jar":"$JEDIT_HOME/jars/SideKick.jar":"$JADE_JAR" \
+-classpath $CP \
    org.gjt.sp.jedit.jEdit $1


### PR DESCRIPTION
Currently the **jason-ide** script does not function correctly on windows using a windows shell emulator. This is due to the classpath string being in an incompatible format. This PR checks for a windows bash interpreter and modifies the classpath as such.

I understand this is somewhat hacky, however this caused me a lot of confusion when first downloading so it may help others.