### PR TITLE
Adding parsing tests for common mistakes. 

### DIFF
--- a/src/test/java/test/ASMistakesTest.java
+++ b/src/test/java/test/ASMistakesTest.java
@@ -1,0 +1,50 @@
+package test;
+
+import jason.asSyntax.ASSyntax;
+import jason.asSyntax.Plan;
+import jason.asSyntax.parser.ParseException;
+import junit.framework.TestCase;
+
+/** JUnit test case for syntax package */
+public class ASMistakesTest extends TestCase {
+
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public void testOpenParenthesis() {
+        Throwable e = null;
+        try {
+            ASSyntax.parseTerm("{ +!p <- .my_name(_34Me }");
+            fail("An expected exception did not occurred.");
+        } catch(Throwable ex) {
+            e = ex;
+        }
+        assertTrue(e instanceof ParseException);
+    }
+
+    public void testMultilineComment() {
+        Throwable e = null;
+        try {
+            ASSyntax.parseTerm("{ +!p <- .print(Hello) /* comment * }");
+            fail("An expected exception did not occurred.");
+        } catch(Throwable ex) {
+            e = ex;
+        }
+        assertTrue(e instanceof ParseException);
+    }
+
+    public void testOpenQuotes() {
+        Throwable e = null;
+        try {
+            ASSyntax.parseTerm("{ +!p <- .print(\"Hello) }");
+            fail("An expected exception did not occurred.");
+        } catch(Throwable ex) {
+            e = ex;
+        }
+        assertTrue(e instanceof ParseException);
+    }
+   
+
+
+}

--- a/src/test/java/test/asunit/BugInference.java
+++ b/src/test/java/test/asunit/BugInference.java
@@ -9,7 +9,6 @@ import jason.asSyntax.ASSyntax;
 import jason.asSyntax.Literal;
 import jason.asSyntax.parser.ParseException;
 import jason.asunit.TestAgent;
-import junit.framework.TestCase;
 
 /** based on bug found by Cranefield */
 public class BugInference {


### PR DESCRIPTION
This PR is not passing on tests because it was expected to generate a parser exception in a mistake like .print("Hello).

Known issue: parser is not throwing an exception for open quotes.

