### PR TITLE
WIP. Now test_assert is independent. Created tester_agent.

### DIFF
--- a/src/test/jason/asl/stdlib/current_intention.asl
+++ b/src/test/jason/asl/stdlib/current_intention.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/stdlib/desire.asl
+++ b/src/test/jason/asl/stdlib/desire.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/stdlib/drop_all_desires.asl
+++ b/src/test/jason/asl/stdlib/drop_all_desires.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/stdlib/drop_all_events.asl
+++ b/src/test/jason/asl/stdlib/drop_all_events.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/stdlib/drop_all_intentions.asl
+++ b/src/test/jason/asl/stdlib/drop_all_intentions.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/stdlib/drop_desire.asl
+++ b/src/test/jason/asl/stdlib/drop_desire.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/stdlib/drop_event.asl
+++ b/src/test/jason/asl/stdlib/drop_event.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/stdlib/drop_intention.asl
+++ b/src/test/jason/asl/stdlib/drop_intention.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/stdlib/eval.asl
+++ b/src/test/jason/asl/stdlib/eval.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/stdlib/fail_goal.asl
+++ b/src/test/jason/asl/stdlib/fail_goal.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/stdlib/intend.asl
+++ b/src/test/jason/asl/stdlib/intend.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/stdlib/intention.asl
+++ b/src/test/jason/asl/stdlib/intention.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/stdlib/resume.asl
+++ b/src/test/jason/asl/stdlib/resume.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/stdlib/substring.asl
+++ b/src/test/jason/asl/stdlib/substring.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/stdlib/succeed_goal.asl
+++ b/src/test/jason/asl/stdlib/succeed_goal.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/stdlib/suspend.asl
+++ b/src/test/jason/asl/stdlib/suspend.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/stdlib/suspended.asl
+++ b/src/test/jason/asl/stdlib/suspended.asl
@@ -4,7 +4,7 @@
  * Most of examples come from Jason's documentation
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 !execute_test_plans.
 

--- a/src/test/jason/asl/test_sample_agent.asl
+++ b/src/test/jason/asl/test_sample_agent.asl
@@ -10,7 +10,7 @@
  * starting with @test (e.g.: @test_sum[atomic])
  */
 
-{ include("test_assert.asl") }
+{ include("tester_agent.asl") }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
      A G E N T    I N I T I A L    B B    A N D    R U L E S

--- a/src/test/jason/inc/test_assert.asl
+++ b/src/test/jason/inc/test_assert.asl
@@ -2,8 +2,6 @@
  * Assert helpers
  */
 
-{ include("test_manager.asl") }
-
 /**
  * Asserts if X is equals to Y
  * IMPORTANT! Do no use this method to compare float numbers
@@ -18,7 +16,7 @@
         .log(severe,"Intention ",ID," FAILED! Assert equals expected ",X," but had ",Y);
         .fail;
     } else {
-        .send(test_manager,achieve,count_tests(passed));
+        -+test_passed;
         .log(info,"Intention ",ID," PASSED");
     }
 .
@@ -38,13 +36,13 @@
             .fail;
         }
     }
-    .send(test_manager,achieve,count_tests(passed));
+    -+test_passed;
     .log(info,"Intention ",ID," PASSED");
 .
 -!assert_equals(X,Y) :
     true
     <-
-    .send(test_manager,achieve,count_tests(failed));
+    -+test_failed;
 .
 
 /**
@@ -60,14 +58,14 @@
         .log(severe,"Intention ",ID," FAILED! Assert equals expected ",X,"+/-",T,", but had ",Y);
         .fail;
     } else {
-        .send(test_manager,achieve,count_tests(passed));
+        -+test_passed;
         .log(info,"Intention ",ID," PASSED");
     }
 .
 -!assert_equals(X,Y,T) :
     true
     <-
-    .send(test_manager,achieve,count_tests(failed));
+    -+test_failed;
 .
 
 /**
@@ -82,14 +80,14 @@
         .log(severe,"Intention ",ID," FAILED! Assert true expected ",X);
         .fail;
     } else {
-        .send(test_manager,achieve,count_tests(passed));
+        -+test_passed;
         .log(info,"Intention ",ID," PASSED");
     }
 .
 -!assert_true(X) :
     true
     <-
-    .send(test_manager,achieve,count_tests(failed));
+    -+test_failed;
 .
 
 /**
@@ -104,14 +102,14 @@
         .log(severe,"Intention ",ID," FAILED! Assert false expected not ",X);
         .fail;
     } else {
-        .send(test_manager,achieve,count_tests(passed));
+        -+test_passed;
         .log(info,"Intention ",ID," PASSED");
     }
 .
 -!assert_false(X) :
     true
     <-
-    .send(test_manager,achieve,count_tests(failed));
+    -+test_failed;
 .
 
 /**
@@ -122,13 +120,13 @@
     .current_intention(I) &
     I = intention(ID,_)
     <-
-    .send(test_manager,achieve,count_tests(passed));
+    -+test_passed;
     .log(info,"Intention ",ID," PASSED");
 .
 -!force_pass : // Only pass if not applicable
     true
     <-
-    .send(test_manager,achieve,count_tests(failed));
+    -+test_failed;
 .
 
 /**
@@ -145,7 +143,7 @@
 -!force_failure(MSG) : // Only failure if not applicable
     true
     <-
-    .send(test_manager,achieve,count_tests(failed));
+    -+test_failed;
 .
 
 /**
@@ -160,11 +158,11 @@
         .log(severe,"Intention ",ID," FAILED! Assert equals expected ",X," but had ",Y);
         .fail;
     }
-    .send(test_manager,achieve,count_tests(passed));
+    -+test_passed;
     .log(info,"Intention ",ID," PASSED");
 .
 -!assert_contains(X,Y) :
     true
     <-
-    .send(test_manager,achieve,count_tests(failed));
+    -+test_failed;
 .

--- a/src/test/jason/inc/test_manager.asl
+++ b/src/test/jason/inc/test_manager.asl
@@ -2,6 +2,9 @@
  * Test manager provides general test configurations and facilities
  */
 
+ /**
+ * Setup statistics
+ */
 tests_performed(0).
 tests_failed(0).
 tests_passed(0).
@@ -16,7 +19,7 @@ shutdown_hook.          // enable to shutdown after finishing tests
  * Startup operations
  */
 !set_controller.          // starts test controller operations
-!create_test_agents.      // create agents by .asl files in test/agt/
+!create_tester_agents.      // create agents by .asl files in test/agt/
 
 /**
  * execute plans that contains "test" in the label
@@ -111,8 +114,8 @@ shutdown_hook.          // enable to shutdown after finishing tests
 /**
  * create agents by files present in folder test/agt/
  */
-@create_agents[atomic]
-+!create_test_agents :
+@create_tester_agents[atomic]
++!create_tester_agents :
     .my_name(test_manager)
     <-
     .list_files("./src/test/jason/inc",".*.asl",IGNORE);
@@ -130,7 +133,7 @@ shutdown_hook.          // enable to shutdown after finishing tests
       }
     }
 .
-+!create_test_agents. // avoid plan not found for asl that includes controller
++!create_tester_agents. // avoid plan not found for asl that includes controller
 
 /**
  * Statistics for tests (passed/failed)
@@ -144,7 +147,7 @@ shutdown_hook.          // enable to shutdown after finishing tests
     -+tests_passed(P+1);
 .
 @count_tests_failed[atomic]
-+!count_tests(failed) :
++count_tests(failed) :
     tests_performed(N) &
     tests_failed(F)
     <-

--- a/src/test/jason/inc/test_manager.asl
+++ b/src/test/jason/inc/test_manager.asl
@@ -12,7 +12,6 @@ tests_passed(0).
 /**
  * Configurations
  */
-auto_create_fail_plan.  // create a -!test fail plan for each desire starting with "test"
 shutdown_hook.          // enable to shutdown after finishing tests
 
 /**
@@ -20,51 +19,6 @@ shutdown_hook.          // enable to shutdown after finishing tests
  */
 !set_controller.          // starts test controller operations
 !create_tester_agents.      // create agents by .asl files in test/agt/
-
-/**
- * execute plans that contains "test" in the label
- */
-@execute_plans[atomic]
-+!execute_test_plans:
-    .relevant_plans({+!_},_,LL)
-    <-
-    !create_default_fail_plan;
-
-    for (.member(P,LL)) {
-        if (.substring("test",P,0)) {
-            /**
-             * Execute the @test plan
-             */
-            !!execute_test_plan(P);
-        }
-    }
-.
-
-/**
- * Add a default -!P fail plan to generate
- * assert failure for others non expected
- * errors
- */
-@create_default_fail_plan[atomic]
-+!create_default_fail_plan:
-    auto_create_fail_plan
-    <-
-    .add_plan({
-        -!P <-
-            !force_failure("Failure captured by default fail plan -!P.");
-    }, self, end);
-.
-+!create_default_fail_plan. // Do not create plans if it is disabled
-
-@execute_plan[atomic]
-+!execute_test_plan(P) :
-    true
-    <-
-    .current_intention(I);
-    I = intention(Id,IStack);
-    .log(info,"TESTING ",Id," (main plan: ",P,")");
-    !P;
-.
 
 /**
  * setup of the controller, including hook for shutdown

--- a/src/test/jason/inc/tester_agent.asl
+++ b/src/test/jason/inc/tester_agent.asl
@@ -2,8 +2,57 @@
  * Tester agent is an agent managed by test_manager
  */
 
-{ include("test_manager.asl") }
 { include("test_assert.asl") }
+
+/**
+ * Configurations
+ */
+auto_create_fail_plan.  // create -!P fail plan to capture unexpected failures
+
+/**
+ * execute plans that contains "test" in the label
+ */
+@execute_plans[atomic]
++!execute_test_plans:
+    .relevant_plans({+!_},_,LL)
+    <-
+    !create_default_fail_plan;
+
+    for (.member(P,LL)) {
+        if (.substring("test",P,0)) {
+            /**
+             * Execute the @test plan
+             */
+            !!execute_test_plan(P);
+        }
+    }
+.
+
+/**
+ * Add a default -!P fail plan to generate
+ * assert failure for others non expected
+ * errors
+ */
+@create_default_fail_plan[atomic]
++!create_default_fail_plan:
+    auto_create_fail_plan
+    <-
+    .add_plan({
+        -!P <-
+            !force_failure("Failure captured by default fail plan -!P.");
+    }, self, end);
+.
++!create_default_fail_plan. // Do not create plans if it is disabled
+
+@execute_plan[atomic]
++!execute_test_plan(P) :
+    true
+    <-
+    .current_intention(I);
+    I = intention(Id,IStack);
+    .log(info,"TESTING ",Id," (main plan: ",P,")");
+    !P;
+.
 
 /**
  * Send data to test_manager

--- a/src/test/jason/inc/tester_agent.asl
+++ b/src/test/jason/inc/tester_agent.asl
@@ -1,0 +1,23 @@
+/**
+ * Tester agent is an agent managed by test_manager
+ */
+
+{ include("test_manager.asl") }
+{ include("test_assert.asl") }
+
+/**
+ * Send data to test_manager
+ */
+@test_passed[atomic]
++test_passed :
+    true
+    <-
+    .send(test_manager,achieve,count_tests(passed));
+.
+
+@test_failed[atomic]
++test_failed :
+    true
+    <-
+    .send(test_manager,achieve,count_tests(failed));
+.


### PR DESCRIPTION
test_assert now is an independent and reusable library. For applications that want to use the test apparatus which generate statistics, hooks the shutdown among other features, the testing agent should include tester_agent.asl. tester_agent.asl already brings test_assert.asl helper, so a testing agent should not include this helper.

This is a Work in progress (WIP), since this new structure also brought some interesting thoughts regarding some plans that are currently on test_manager and maybe can be moved to tester_agent. Ideally, tester_agent should not include test_manager.