### PR TITLE
Now using .intention(I,_,_,current)

### DIFF
--- a/src/test/jason/asl/stdlib/fail_goal.asl
+++ b/src/test/jason/asl/stdlib/fail_goal.asl
@@ -35,6 +35,7 @@
 
 +!test_fail_goal
     <-
+    .log(warning,"TODO: +!test_fail_goal <- !assert_true(failed) has no current intention!");
     !assert_true(failed); // It is expected ^!go has added 'failed' to bb
 .
 

--- a/src/test/jason/inc/test_assert.asl
+++ b/src/test/jason/inc/test_assert.asl
@@ -8,7 +8,7 @@
  */
 @assert_equals[atomic]
 +!assert_equals(X,Y) :
-    .intention(ID,_) &
+    .intention(ID,_,_,current) &
     not .list(X) & not .list(Y)
     <-
     if (X \== Y) {
@@ -20,7 +20,7 @@
     }
 .
 +!assert_equals(X,Y) :
-    .intention(ID,_)
+    .intention(ID,_,_,current)
     <-
     for (.member(Xth,X)) {
         if (not .member(Xth,Y)) {
@@ -49,7 +49,7 @@
  */
 @assert_equals_tolerant[atomic]
 +!assert_equals(X,Y,T) :
-    .intention(ID,_)
+    .intention(ID,_,_,current)
     <-
     if (not (Y >= X-T & Y <= X+T)) {
         .log(severe,"Intention ",ID," FAILED! Assert equals expected ",X,"+/-",T,", but had ",Y);
@@ -71,6 +71,7 @@
 @assert_true[atomic]
 +!assert_true(X) :
     .intention(ID,_)
+    //.intention(ID,_,_,current)
     <-
     if (not X) {
         .log(severe,"Intention ",ID," FAILED! Assert true expected ",X);
@@ -91,7 +92,7 @@
  */
 @assert_false[atomic]
 +!assert_false(X) :
-    .intention(ID,_)
+    .intention(ID,_,_,current)
     <-
     if (X) {
         .log(severe,"Intention ",ID," FAILED! Assert false expected not ",X);
@@ -112,7 +113,7 @@
  */
 @force_pass[atomic]
 +!force_pass :
-    .intention(ID,_)
+    .intention(ID,_,_,current)
     <-
     -+test_passed;
     .log(info,"Intention ",ID," PASSED");
@@ -128,7 +129,7 @@
  */
 @force_failure[atomic]
 +!force_failure(MSG) :
-    .intention(ID,_)
+    .intention(ID,_,_,current)
     <-
     .log(severe,"Intention ",ID," forcedly FAILED! Msg: ",MSG);
     .fail;
@@ -144,7 +145,7 @@
  */
 @assert_contains[atomic]
 +!assert_contains(X,Y) :
-    .intention(ID,_)
+    .intention(ID,_,_,current)
     <-
     if (not .member(Y,X)) {
         .log(severe,"Intention ",ID," FAILED! Assert equals expected ",X," but had ",Y);

--- a/src/test/jason/inc/tester_agent.asl
+++ b/src/test/jason/inc/tester_agent.asl
@@ -46,9 +46,9 @@ auto_create_fail_plan.  // create -!P fail plan to capture unexpected failures
 
 @execute_plan[atomic]
 +!execute_test_plan(P) :
-    .intention(Id,_)
+    .intention(ID,_,_,current)
     <-
-    .log(info,"TESTING ",Id," (main plan: ",P,")");
+    .log(info,"TESTING ",ID," (main plan: ",P,")");
     !P;
 .
 


### PR DESCRIPTION
Now using .intention(I,_,_,current) for current intention, instead of .intention(I,_).

However, for some reason a test seems to do not present a current intention, it is on fail_goal.asl, plan called: +!test_fail_goal. Is this behaviour expected?

Besides, I suggest to change the message on .current_intention to:
ts.getLogger().warning(".current_intention(I) was replaced by .intention(I,_,_,current)");