### PR TITLE
#59 seed support for random functions

### DIFF
--- a/src/main/java/jason/functions/Random.java
+++ b/src/main/java/jason/functions/Random.java
@@ -4,6 +4,7 @@ import jason.asSemantics.DefaultArithFunction;
 import jason.asSemantics.TransitionSystem;
 import jason.asSyntax.NumberTerm;
 import jason.asSyntax.Term;
+import jason.stdlib.RandomSingelton;
 
 /**
    <p>Function: <b><code>math.random(N)</code></b>: encapsulates java Math.random;
@@ -30,9 +31,9 @@ public class Random extends DefaultArithFunction  {
     @Override
     public double evaluate(TransitionSystem ts, Term[] args) throws Exception {
         if (args.length == 1 && args[0].isNumeric()) {
-            return Math.random() * ((NumberTerm)args[0]).solve();
+            return RandomSingelton.nextDouble() * ((NumberTerm)args[0]).solve();
         } else {
-            return Math.random();
+            return RandomSingelton.nextDouble();
         }
     }
 

--- a/src/main/java/jason/stdlib/RandomSingelton.java
+++ b/src/main/java/jason/stdlib/RandomSingelton.java
@@ -1,0 +1,27 @@
+package jason.stdlib;
+
+import java.util.Random;
+
+/**
+ Manages the random number generator (and its seed) for:
+ @see jason.functions.Random
+ @see jason.stdlib.random
+
+ @author Timotheus Kampik
+*/
+
+public class RandomSingelton {
+    private static Random random = new Random();
+
+    public static void setSeed(long seed) {
+        random.setSeed(seed);
+    }
+
+    public static double nextDouble() {
+        return random.nextDouble();
+    }
+
+    public static int nextInt(int bound) {
+        return random.nextInt(bound);
+    }
+}

--- a/src/main/java/jason/stdlib/package-info.java
+++ b/src/main/java/jason/stdlib/package-info.java
@@ -152,6 +152,7 @@ Internal actions of Jason.
   <li>{@link jason.stdlib.range range}: backtrack values in a range (used in <b>for</b>).</li>
 
   <li>{@link jason.stdlib.random random}: produces random numbers.</li>
+  <li>{@link jason.stdlib.set_random_seed math.set_random_seed}: sets the seed of Jason's random number generator.</li>
 
   <li>{@link jason.stdlib.include include}: imports a source code at run time.</li>
 

--- a/src/main/java/jason/stdlib/random.java
+++ b/src/main/java/jason/stdlib/random.java
@@ -2,11 +2,9 @@ package jason.stdlib;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 
 import jason.JasonException;
 import jason.asSemantics.DefaultInternalAction;
-import jason.asSemantics.InternalAction;
 import jason.asSemantics.TransitionSystem;
 import jason.asSemantics.Unifier;
 import jason.asSyntax.ListTerm;
@@ -60,15 +58,6 @@ import jason.asSyntax.Term;
 @SuppressWarnings("serial")
 public class random extends DefaultInternalAction {
 
-    private static InternalAction singleton = null;
-    public static InternalAction create() {
-        if (singleton == null)
-            singleton = new random();
-        return singleton;
-    }
-
-    private Random random = new Random();
-
     @Override public int getMinArgs() {
         return 1;
     }
@@ -96,7 +85,7 @@ public class random extends DefaultInternalAction {
     public Object execute(final TransitionSystem ts, final Unifier un, final Term[] args) throws Exception {
         checkArguments(args);
         if (args.length == 1) {
-            return un.unifies(args[0], new NumberTermImpl(random.nextDouble()));
+            return un.unifies(args[0], new NumberTermImpl(RandomSingelton.nextDouble()));
         } else {
             final ListTerm l;
             final int      max;
@@ -124,9 +113,9 @@ public class random extends DefaultInternalAction {
                 public Unifier next() {
                     Unifier c = un.clone();
                     if (l == null)
-                        c.unifies(args[0], new NumberTermImpl(random.nextDouble()));
+                        c.unifies(args[0], new NumberTermImpl(RandomSingelton.nextDouble()));
                     else
-                        c.unifies(args[1], j.get(random.nextInt(j.size())));
+                        c.unifies(args[1], j.get(RandomSingelton.nextInt(j.size())));
                     n++;
                     return c;
                 }

--- a/src/main/java/jason/stdlib/set_random_seed.java
+++ b/src/main/java/jason/stdlib/set_random_seed.java
@@ -1,0 +1,60 @@
+package jason.stdlib;
+
+import jason.asSemantics.DefaultInternalAction;
+import jason.asSemantics.TransitionSystem;
+import jason.asSemantics.Unifier;
+import jason.asSyntax.NumberTerm;
+import jason.asSyntax.Term;
+
+/**
+ <p>Internal action: <b><code>math.set_random_seed(<i>N</i>)</code></b>.
+
+ <p>Description: sets the seed of Jason's random number generator
+
+ <p>Parameter:<ul>
+
+ <li>- seed (number): the value to which the random seed is to be set</li>
+
+ </ul>
+
+ <p>Example:<ul>
+
+ <li><code>math.set_random_seed(20)</code>: Sets the random number generator's seed to 20.</li>
+ </ul>
+
+ @see jason.functions.Random
+ @see jason.stdlib.random
+
+ */
+@Manual(
+        literal="math.set_random_seed(seed)",
+        hint="generates a random number between 0 and 1",
+        argsHint= {
+                "sets the seed of Jason's random number generator"
+        },
+        argsType= {
+                "number"
+        },
+        examples= {
+                "math.set_random_seed(20): sets the random number generator's seed to 20"
+        },
+        seeAlso= {
+                "jason.functions.Random",
+                "jason.stdlib.random"
+        }
+)
+
+public class set_random_seed extends DefaultInternalAction {
+
+    public String getName() {
+        return "math.set_random_seed";
+    }
+
+    @Override
+    public Object execute(final TransitionSystem ts, final Unifier un, final Term[] args) throws Exception {
+        checkArguments(args);
+        Long seed = (long) ((NumberTerm)args[0]).solve();
+        RandomSingelton.setSeed(seed);
+        return true;
+    }
+}

--- a/src/test/java/test/FunctionsTest.java
+++ b/src/test/java/test/FunctionsTest.java
@@ -1,0 +1,16 @@
+package test;
+
+import jason.asSemantics.Unifier;
+import jason.asSyntax.ASSyntax;
+import jason.asSyntax.Term;
+import jason.asSyntax.VarTerm;
+import junit.framework.TestCase;
+
+public class FunctionsTest extends TestCase {
+    public void testRandom() throws Exception {
+        VarTerm X = new VarTerm("X");
+        Unifier u = new Unifier();
+        new jason.stdlib.set_random_seed().execute(null, u, new Term[] { ASSyntax.parseNumber("0.15")});
+        assertEquals(0.730967787376657, new jason.functions.Random().evaluate(null, new Term[] { X }));
+    }
+}

--- a/src/test/java/test/StdLibTest.java
+++ b/src/test/java/test/StdLibTest.java
@@ -10,21 +10,7 @@ import jason.asSemantics.Intention;
 import jason.asSemantics.Option;
 import jason.asSemantics.TransitionSystem;
 import jason.asSemantics.Unifier;
-import jason.asSyntax.ASSyntax;
-import jason.asSyntax.Atom;
-import jason.asSyntax.ListTerm;
-import jason.asSyntax.ListTermImpl;
-import jason.asSyntax.Literal;
-import jason.asSyntax.NumberTermImpl;
-import jason.asSyntax.Plan;
-import jason.asSyntax.Pred;
-import jason.asSyntax.StringTerm;
-import jason.asSyntax.StringTermImpl;
-import jason.asSyntax.Structure;
-import jason.asSyntax.Term;
-import jason.asSyntax.Trigger;
-import jason.asSyntax.UnnamedVar;
-import jason.asSyntax.VarTerm;
+import jason.asSyntax.*;
 import jason.asSyntax.parser.ParseException;
 import jason.bb.BeliefBase;
 import jason.stdlib.add_annot;
@@ -607,6 +593,15 @@ public class StdLibTest extends TestCase {
         u.unifies(ASSyntax.parseTerm("X"), ASSyntax.parseTerm("floripa"));
         u.bind(new UnnamedVar(26), ASSyntax.parseTerm("blabal"));
         assertTrue((Boolean)new jason.stdlib.puts().execute(ts, u, new Term[] { new StringTermImpl("Hello #{_26}, #{X}")}));
+    }
+
+    public void testRandom() throws Exception {
+        VarTerm X = new VarTerm("X");
+        Unifier u = new Unifier();
+        new jason.stdlib.set_random_seed().execute(null, u, new Term[] { ASSyntax.parseNumber("20")});
+
+        assertTrue((Boolean)new jason.stdlib.random().execute(null, u, new Term[] { X }));
+        assertEquals("0.7320427537419555", u.get(X).toString());
     }
 
     public void testReplace() throws Exception {


### PR DESCRIPTION
Here's my attempt:

Support setting the shared seed of:
* `jason.functions.Random`
* `jason.stdlib.random`
via internal action `set_random_seed(seed)`

Closes #59.

I am not sure about some things, in particular:

* Is the way I use an internal action for "math.set_random_seed(seed)" correct, or should this rather be a function?
* Is it okay that I moved the `random` singelton into its own class?

So far, I only tested with unit tests and did not try it with an actual agent implementation.
