### PR TITLE
Added count_plans to ensure all tests were performed

### DIFF
--- a/src/test/jason/asl/stdlib/intention.asl
+++ b/src/test/jason/asl/stdlib/intention.asl
@@ -16,7 +16,7 @@
      */
     .add_plan({
       +!go(X,Y) <-
-          .wait(50); // An arbitrary delay
+          .wait(150); // An arbitrary delay
     }, self, begin);
 
     // Trigger the mock plan
@@ -28,6 +28,7 @@
 // This plan should not be triggered by the manager
 +!test_intention
     <-
+    .wait(50); // Give some time to finish +!test_launch_intention
     // It is expected to have 3 intentions
     .findall(i(I1,D1),.intention(I1,D1),L1);
     .length(L1,LL1);


### PR DESCRIPTION
Now the number of launched and achieved test plans are compared in order to ensure that all the existing tests are performed. Notice that the number of launched plans is not same as the number of tests, since a test plan may have any number of assertions. In this sense, the final report has a new possible outcome. Besides the previous defined FAILED and PASSED, both regarding some FAILED assertion, now there is another FAILED regarding possible missed tests.

Below a sample output when some plan was not achieved:
```
[test_manager] #115 tests executed, #115 passed and #0 failed.
[test_manager] #33 plans launched, but #31 achieved!
[test_manager] Hook to shutdown FAILED! You may need to give more time for the shutdown.
[test_manager] End of Jason unit tests: FAILED!
```

In this example, there are 24 tester_agents, together they have 33 @[test] plans. These plans have actually 116 assertions, but notice one of these assertions was not executed. This condition is actually hidden since all 115 tests actually passed. Without a test on what is expected to be achieved, the result would give a wrong impression that everything is ok. 

Notice that still it is not guaranteed that everything is being counted since the developer may decide to trigger "no test" plans from @[test] plans. If the shutdown occurs after all @[test] and before finishing a "no test", it is possible to still have wrong results. In this sense, it is recommended to avoid "no test" plans approach.

Another though regards to the hook. In the +!setup_manager plan of test_manager it is possible to set a delay for the programmed shutdown. In case of having missed tests, as suggested by the output message, the developer can set the hook for a longer delay.

