### PR TITLE
Embedding test facilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,7 @@ jar {
     }
     from('src') {
         include '/test/jason/inc/**/*.asl'
+        include '/test/jason/**/*.mas2j'
     }
     /*doFirst {
         Properties props = new Properties()
@@ -567,14 +568,25 @@ task testJason(dependsOn: 'jar') {
             javaexec {
                 main = 'jason.infra.centralised.RunCentralisedMAS'
                 if (gradle.startParameter.logLevel.toString().equals("DEBUG")) {
-                    args = ['src/test/jason/unit_tests.mas2j', '--log-conf', 'src/main/resources/templates/console-debug-logging.properties']
+                    args = [
+                        'jar:file:' + project.buildDir.absolutePath + '/libs/jason-' + project.version+'.jar!/test/jason/unit_tests.mas2j',
+                        '--log-conf',
+                        'jar:file:' + project.buildDir.absolutePath + '/libs/jason-' + project.version+'.jar!/templates/console-debug-logging.properties'
+                    ]
                 } else if (gradle.startParameter.logLevel.toString().equals("INFO")) {
-                    args = ['src/test/jason/unit_tests.mas2j', '--log-conf', 'src/main/resources/templates/console-info-logging.properties']
+                    args = [
+                        'jar:file:' + project.buildDir.absolutePath + '/libs/jason-' + project.version+'.jar!/test/jason/unit_tests.mas2j',
+                        '--log-conf',
+                        'jar:file:' + project.buildDir.absolutePath + '/libs/jason-' + project.version+'.jar!/templates/console-info-logging.properties'
+                    ]
                 } else {
-                    args = ['src/test/jason/unit_tests.mas2j', '--log-conf', 'src/main/resources/templates/console-lifecycle-logging.properties']
+                    args = [
+                        'jar:file:' + project.buildDir.absolutePath + '/libs/jason-' + project.version+'.jar!/test/jason/unit_tests.mas2j',
+                        '--log-conf',
+                        'jar:file:' + project.buildDir.absolutePath + '/libs/jason-' + project.version+'.jar!/templates/console-lifecycle-logging.properties'
+                    ]
                 }
                 classpath sourceSets.main.runtimeClasspath
-                sourceSets.test.java.srcDirs += ['src/test/jason/jia']
 
                 errorOutput = new ByteArrayOutputStream()
                 standardOutput = new ByteArrayOutputStream()

--- a/src/main/java/jason/infra/centralised/RunCentralisedMAS.java
+++ b/src/main/java/jason/infra/centralised/RunCentralisedMAS.java
@@ -126,7 +126,14 @@ public class RunCentralisedMAS extends BaseCentralisedMAS implements RunCentrali
 
         Map<String,Object> mArgs = parseArgs(args);
 
-        setupLogger((String)mArgs.get("log-conf"));
+        String logFile = (String)mArgs.get("log-conf");
+        if (logFile.startsWith("jar")) {
+            String outerPrefix = logFile.substring(0,logFile.indexOf("!")+1) + "/";
+            SourcePath aslSourcePath = new SourcePath();
+            logFile = aslSourcePath.fixPath(logFile, outerPrefix);
+        }
+        System.err.println("logfile "+logFile);
+        setupLogger(logFile);
 
         if ((boolean)(mArgs.getOrDefault("debug", false))) {
             debug = true;

--- a/src/test/jason/asl/stdlib/at.asl
+++ b/src/test/jason/asl/stdlib/at.asl
@@ -9,43 +9,61 @@
 !execute_test_plans.
 
 @[test]
-+!test_launch_at
++!test_at
     <-
+    .log(warning,"TODO: Uncomment lines below, .at with no metric unit is supposed to be in milli!");
+    //.nano_time(T);
+    //.at("now +500", {+!g(test0,T)});
+
     .nano_time(T0);
-    !assert_false(executed(g0));
-    .log(warning,"TODO: Error on at using miliseconds! .at with no metric unit is supposed to be in mili!");
-    //.at("now +500", {+!g(test1,T0)});
+    .at("now +500 ms", {+!g(test1,T0)});
     .wait(550);
-    //!test_at_test1;
+    !assert_true(executed(test1,_,_));
+    ?executed(test1,T0,T1);
+    /**
+     * Tolerance of 50 ms. Hopefully it is enough
+     * for the machines that may run this test
+     */
+    !assert_between((T1-T0)/1000000,500,550);
 
     .nano_time(T2);
     !assert_false(executed(g1));
     .at("now +1 s", {+!g(test2,T2)});
     .wait(1050);
-    .log(warning,"TODO: at not working as expected! Is the thread of the agent stopped? How to test at?");
-    //!test_at_test2;
 
-    .log(warning,"TODO: Create tests for different formats of 'when' parameter");
-    //.at("now +1 second", {+!g(g1)});
-    //.at("now +1 seconds", {+!g(g1)});
-.
-
-+!test_at_test1
-    <-
-    !assert_true(executed(test1,_,_));
-
-    ?executed(test1,T0,T1);
-    Tmili = (T1-T0)/1000000;
-    !assert_greaterthan(Tmili,500);
-.
-
-+!test_at_test2
-    <-
     !assert_true(executed(test2,_,_));
+    ?executed(test2,T2,T3);
+    /**
+     * Tolerance of 50 ms. Hopefully it is enough
+     * for the machines that may run this test
+     */
+    !assert_between((T3-T2)/1000000,1000,1050);
 
-    ?executed(test2,T0,T1);
-    Tmili = (T1-T0)/1000000;
-    !assert_greaterthan(Tmili,1000);
+    .at("now +1 second", {+!g(test3,_)}); // Just checking if no parse error is produced
+    .at("now +1 seconds", {+!g(test4,_)}); // Just checking if no parse error is produced
+    .at("now +1 m", {+!g(test5,_)}); // Just checking if no parse error is produced
+    .at("now +1 minute", {+!g(test6,_)}); // Just checking if no parse error is produced
+    .at("now +1 minutes", {+!g(test7,_)}); // Just checking if no parse error is produced
+    .at("now +1 h", {+!g(test8,_)}); // Just checking if no parse error is produced
+    .at("now +1 hour", {+!g(test9,_)}); // Just checking if no parse error is produced
+    .at("now +1 hours", {+!g(test10,_)}); // Just checking if no parse error is produced
+    .at("now +1 d", {+!g(test11,_)}); // Just checking if no parse error is produced
+    .at("now +1 day", {+!g(test12,_)}); // Just checking if no parse error is produced
+    .at("now +1 days", {+!g(test13,_)}); // Just checking if no parse error is produced
+.
+
+/**
+ * Since this plan is atomic, the agent will not
+ * perform !g until !test_at_atomic has an end.
+ * This agent is focused in one goal, other plans
+ * should not be executed, assertiong should be false.
+ */
+@[atomic,test]
++!test_at_atomic
+<-
+    .at("now +500 ms", {+!g(test100,T0)});
+    .wait(550);
+    !assert_false(executed(test100,_,_));
 .
 
 +!g(X,T)

--- a/src/test/jason/asl/stdlib/intend.asl
+++ b/src/test/jason/asl/stdlib/intend.asl
@@ -9,7 +9,7 @@
 !execute_test_plans.
 
 @[test]
-+!test_launch_intend
++!test_intend
     <-
     /**
      * Add a mock plan for go(X,Y)
@@ -24,17 +24,9 @@
     // Trigger the mock plan
     !!go(1,3);
 
-    //!assert_true(.intend(go(1,3)));
-    .log(warning,"TODO: Even when test_launch_intend is not atomic go/2 does not appear on intentions list");
+    !assert_true(.intend(go(1,3)));
 
-    !!test_intend;
-.
-
-+!test_intend
-    <-
     // Print intentions
     .findall(D,.intend(D),L);
     .log(info,"Intentions: ",L);
-
-    !assert_true(.intend(go(1,3)));
 .

--- a/src/test/jason/asl/stdlib/send.asl
+++ b/src/test/jason/asl/stdlib/send.asl
@@ -38,11 +38,11 @@
     <-
     .create_agent(tom);
     .send(tom, tellHow, "+?retrieve_info(X,Y) <- .wait(100); Y = X + 1.");
-    .send(tom,askOne,retrieve_info(1,Z0),retrieve_info(_,Z0),110); // give enough time to answer
-    .wait(200);
+    .send(tom,askOne,retrieve_info(1,Z0),retrieve_info(_,Z0),200); // give enough time to answer
+    .wait(220);
     !assert_equals(2,Z0);
     .send(tom,askOne,retrieve_info(10,Z1),Z1,50); // let the timeout expires
-    .wait(200);
+    .wait(220);
     !assert_equals(timeout,Z1);
     .kill_agent(tom);
 .

--- a/src/test/jason/asl/stdlib/send.asl
+++ b/src/test/jason/asl/stdlib/send.asl
@@ -135,6 +135,7 @@
     !assert_true(C);
     //The plan body starts with ".send("
     !assert_true(.substring(".send(",B,0));
+    .kill_agent(maria);
 .
 
 @hp +!hello(Who)  <- +greeted(Who).

--- a/src/test/jason/asl/test_failure_event.asl
+++ b/src/test/jason/asl/test_failure_event.asl
@@ -9,22 +9,20 @@
 !execute_test_plans.
 
 /**
- * Test fail event
+ * Test fail event and action_failed
  */
-@[atomic,test]
-+!test_fail_event :
-    true
+@[test]
++!test_fail_event
     <-
     non_existing_action;
 .
--!test_fail_event[error(ErrorId), error_msg(Msg), code(CodeBody), code_src(CodeSrc), code_line(CodeLine)] :
-    true
+-!test_fail_event[error(ErrorId), error_msg(Msg), code(CodeBody), code_src(CodeSrc), code_line(CodeLine)]
    <-
    .log(warning,"TODO: Remove !check_test_fail_event and uncomment asserts, notice the output says assert_equals on event 'unknown', i.e., -!events has no intention? Due to this issue all asserts return failure!");
 
    //This !check_test_fail_event was created just to performed the asserts below. When the problem is solved it can be removed and asserts uncommented
    !check_test_fail_event(ErrorId,Msg,CodeBody,CodeSrc,CodeLine);
-   //!assert_equals("action_failed",ErrorId);
+   //!assert_equals(action_failed,ErrorId);
    //!assert_equals("test_failure_event.asl",CodeSrc);
 
    .print("Expected error: ", ErrorId, " '",Msg,"' by ",CodeBody," in ",CodeSrc,":",CodeLine);
@@ -37,25 +35,21 @@
 .
 
 /**
- * Test generic fail event
+ * Test generic fail event and ia_failed
  */
-@[atomic,test]
-+!test_generic_fail_event :
-    true
+@[test]
++!test_generic_fail_event
     <-
     .fail;
 .
-//-!F[error(ErrorId), error_msg(Msg), code(CodeBody), code_src(CodeSrc), code_line(CodeLine)] :
--!test_generic_fail_event[error(ErrorId), error_msg(Msg), code(CodeBody), code_src(CodeSrc), code_line(CodeLine)] :
-    true
+-!F[error(ErrorId), error_msg(Msg), code(CodeBody), code_src(CodeSrc), code_line(CodeLine)]
     <-
     .log(warning,"TODO: Remove !check_test_fail_event and uncomment asserts, notice the output says assert_equals on event 'unknown', i.e., -!events has no intention? Due to this issue all asserts return failure!");
-    .log(warning,"TODO: Remove -!test_generic_fail_event and uncomment -!F, notice a generic fail event -!F does not work with annotations. It just consume the failures and does not throw any exception giving wrong idea that everything is fine.");
 
     //This !check_test_generic_fail_event was created just to performed the asserts below. When the problem is solved it can be removed and asserts uncommented
     !check_test_generic_fail_event(ErrorId,Msg,CodeBody,CodeSrc,CodeLine);
 
-    //!assert_equals("ia_failed",ErrorId);
+    //!assert_equals(ia_failed,ErrorId);
     //!assert_equals("test_failure_event.asl",CodeSrc);
 
     .print("Expected error: ", ErrorId, " '",Msg,"' by ",CodeBody," in ",CodeSrc,":",CodeLine);

--- a/src/test/jason/asl/test_sample_performance.asl
+++ b/src/test/jason/asl/test_sample_performance.asl
@@ -41,7 +41,7 @@ nearest_b(T,X,Y) :-
     !assert_equals(2,Y2);
     !check_performance(testNearest_aPerformance,30,R0);
     !check_performance(testNearest_bPerformance,30,R1);
-    !assert_greaterthan(R0,R1);
+    !assert_greater_than(R0,R1);
 .
 +!testNearest_aPerformance :
     true

--- a/src/test/jason/inc/self_tester.asl
+++ b/src/test/jason/inc/self_tester.asl
@@ -82,6 +82,19 @@ tests_passed(0).
     !assert_contains([1,2],1);  //should pass
     !assert_contains([1,2],3);  //should fail
 
+    !assert_greater_than(1.01,1);  //should pass
+    !assert_greater_than(-1.01,1);  //should fail
+
+    !assert_greater_than_equals(1,1);  //should pass
+    !assert_greater_than_equals(-1,1);  //should fail
+
+    !assert_between(1,0.99,1);  //should pass
+    !assert_between(1,1,1.01);  //should pass
+    !assert_between(1,1,1);  //should pass
+    !assert_between(0.99,1,1);  //should fail
+    !assert_between(1.01,1,1);  //should fail
+    !assert_between(1.0,-1,0);  //should fail
+
     .log(severe,">>> asserting if self tests went right");
     .log(severe,">>> notice that no fails are expected from now on");
 
@@ -91,9 +104,9 @@ tests_passed(0).
     ?tests_failed(F);
 
     // check if everything expected pass and fails have occurred
-    !assert_equals(14,N);
-    !assert_equals(7,P);
-    !assert_equals(7,F);
+    !assert_equals(24,N);
+    !assert_equals(12,P);
+    !assert_equals(12,F);
 
     .log(severe,">>> end of self tests.");
 .

--- a/src/test/jason/inc/test_assert.asl
+++ b/src/test/jason/inc/test_assert.asl
@@ -212,17 +212,62 @@
 /**
  * Asserts if X is greater than Y
  */
-@assert_greaterthan[atomic]
-+!assert_greaterthan(X,Y) : // compare terms
+@assert_greater_than[atomic]
++!assert_greater_than(X,Y) : // compare terms
     .intention(ID,_,[ im(Label,{+!Goal[An]},{ Test; _ },_)|_],current) &
     _[code_line(Line),code_src(Src)] = Label &
     .number(X) & .number(Y)
     <-
     if (X <= Y) {
-        .log(severe,"assert_greaterthan on event '",Goal,"' starting at line ",Line," FAILED! Expected ",X," > ",Y);
+        .log(severe,"assert_greater_than on event '",Goal,"' starting at line ",Line," FAILED! Expected ",X," > ",Y);
         .fail;
     } else {
-        +test(Test,passed,Src,Line)[assert_greaterthan(X,Y)];
-        .log(info,"assert_greaterthan on event '",Goal,"' PASSED");
+        +test(Test,passed,Src,Line)[assert_greater_than(X,Y)];
+        .log(info,"assert_greater_than on event '",Goal,"' PASSED");
     }
+.
+-!assert_greater_than(X,Y)
+    <-
+    +test(Test,failed,Src,Line)[assert_greater_than(X,Y)];
+.
+
+/**
+ * Asserts if X is greater/equal than Y
+ */
+@assert_greater_than_equals[atomic]
++!assert_greater_than_equals(X,Y) : // compare terms
+    .intention(ID,_,[ im(Label,{+!Goal[An]},{ Test; _ },_)|_],current) &
+    _[code_line(Line),code_src(Src)] = Label &
+    .number(X) & .number(Y)
+    <-
+    if (X < Y) {
+        .log(severe,"assert_greater_than_equals on event '",Goal,"' starting at line ",Line," FAILED! Expected ",X," > ",Y);
+        .fail;
+    } else {
+        +test(Test,passed,Src,Line)[assert_greater_than_equals(X,Y)];
+        .log(info,"assert_greater_than_equals on event '",Goal,"' PASSED");
+    }
+.
+-!assert_greater_than_equals(X,Y)
+    <-
+    +test(Test,failed,Src,Line)[assert_greater_than_equals(X,Y)];
+.
+
+@assert_between[atomic]
++!assert_between(X,Y0,Y1) : // compare if X is greater/equal than Y0 and lower/equal than Y1
+    .intention(ID,_,[ im(Label,{+!Goal[An]},{ Test; _ },_)|_],current) &
+    _[code_line(Line),code_src(Src)] = Label &
+    .number(X) & .number(Y0) & .number(Y1)
+    <-
+    if ((X < Y0) | (X > Y1)) {
+        .log(severe,"assert_between on event '",Goal,"' starting at line ",Line," FAILED! Expected ",Y0," <= ",X," <= ",Y1);
+        .fail;
+    } else {
+        +test(Test,passed,Src,Line)[assert_between(X,Y0,Y1)];
+        .log(info,"assert_between on event '",Goal,"' PASSED");
+    }
+.
+-!assert_between(X,Y0,Y1)
+    <-
+    +test(Test,failed,Src,Line)[assert_between(X,Y0,Y1)];
 .

--- a/src/test/jason/inc/test_manager.asl
+++ b/src/test/jason/inc/test_manager.asl
@@ -46,9 +46,6 @@ shutdown_hook.          // shutdown after shutdown_delay(SD), SD is the number o
     .log(severe,"\n\n");
     .log(severe,"#",N," tests executed, #",P," passed and #",F," FAILED.");
     .log(severe,"End of Jason unit tests: FAILED!\n\n");
-    for (test_statistics(R,T,A)) {
-        .log(fine,"Agent '",A,"' ",R," test '",T,"'");
-    }
     .stopMAS(0,1);
  .
 @shutdown_after_skipped[atomic]
@@ -65,11 +62,12 @@ shutdown_hook.          // shutdown after shutdown_delay(SD), SD is the number o
     .log(severe,"\n\n");
     .log(severe,"#",N," tests executed, #",P," passed and #",F," failed.");
     .log(severe,"#",LP," plans launched, but #",AP," achieved!");
+
+    for (plan_statistics(launched,T,A) & not plan_statistics(achieved,T,A)) {
+        .log(severe,"Test '",T,"' was NOT ACHIEVED, agent '",A,"' has FAILED on testing!");
+    }
     .log(severe,"Hook to shutdown FAILED! You may need to set a higher shutdown_delay(SD).");
     .log(severe,"End of Jason unit tests: FAILED!\n\n");
-    for (test_statistics(R,T,A)) {
-        .log(fine,"Agent '",A,"' ",R," test '",T,"'");
-    }
     .stopMAS(0,1);
 .
 @shutdown_after_success[atomic]
@@ -85,9 +83,6 @@ shutdown_hook.          // shutdown after shutdown_delay(SD), SD is the number o
     .log(info,"\n\n");
     .log(info,"#",N," tests executed, #",P," PASSED and #",F," failed.");
     .log(info,"End of Jason unit tests: PASSED\n\n");
-    for (test_statistics(R,T,A)) {
-        .log(fine,"Agent '",A,"' ",R," test '",T,"'");
-    }
     .stopMAS;
 .
 +!shutdown_after_tests // If there is an active intention
@@ -135,5 +130,5 @@ shutdown_hook.          // shutdown after shutdown_delay(SD), SD is the number o
 @count_plans[atomic]
 +!count_plans(R,P,A) // R \in [launched,achieved]
     <-
-    +plan_statistics(R,T,A);
+    +plan_statistics(R,P,A);
 .

--- a/src/test/jason/inc/tester_agent.asl
+++ b/src/test/jason/inc/tester_agent.asl
@@ -40,11 +40,11 @@ auto_create_fail_plan.  // create -!P fail plan to capture unexpected failures
     auto_create_fail_plan
     <-
     .add_plan({
-        -!P[code(C),code_src(S),code_line(L),error_msg(M)] :
+        -!P[error(E),code(C),code_src(S),code_line(L),error_msg(M)] :
             true
             <-
             .log(severe,
-                "The event '",C,"' on '",S,"' at line ",L," FAILED! Message: '",M,"' Error on code/parser! ",
+                "Error '",E,"' in '",S,"' on event '",C,"' at line ",L," FAILED! Message: '",M,"' Error on code/parser! ",
                 "No test statistics will be displayed.");
             .stopMAS(0,1);
     }, self, end);

--- a/src/test/jason/inc/tester_agent.asl
+++ b/src/test/jason/inc/tester_agent.asl
@@ -19,6 +19,7 @@ auto_create_fail_plan.  // create -!P fail plan to capture unexpected failures
     <-
     !create_default_fail_plan;
 
+    +executing_test_plans(ME);
     for (.member(Label[test],LL)) {
         .findall(T, .member(P,LP) & P = {@L +!T : C <- B} & Label = L, Plans);
         .member(Plan,Plans); // it is expected only one plan in the list


### PR DESCRIPTION
This is a work in progress! Do not merge until fixing the paths processing.

The problem it is addressing is how to embed all test facilities into Jason in order to a project that uses jason.jar can do unit-tests of its own asl files, using the unit-tests facilities such as tests management which gives support to Continuous Integration services.

Currently, most of the classes in src/test/jason/ are already embeded, but besides the need to add into the build.gradle of the user's project the task testJason, the user also must have the project unit-tests.mas2j, the agent test_manager and logging.properties files for the different verbosity of tests. It seems that the task of gradle would be solved when a grade plugin for jason is developed. For the other files, I am trying to use a mas2j that comes from the jar, as well as the logging properties and agent test_manager.