### PR TITLE
Created mock_agent skeleton and !wait_idle to avoid .wait of arbitrar…

### DIFF
--- a/src/test/jason/asl/stdlib/send.asl
+++ b/src/test/jason/asl/stdlib/send.asl
@@ -14,7 +14,7 @@
 @[test]
 +!test_send
     <-
-    .create_agent(rafael);
+    !create_mock_agent(rafael);
 
     .send(rafael, tell, vl(10));
     .send(rafael, askOne, vl(X), Y0);
@@ -22,9 +22,9 @@
     !assert_equals(10,Z);
 
     .send(rafael, tellHow, "+!goto(X,Y)[source(Ag)] <- .send(Ag, tell, my_position(X,Y)).");
-    .wait(200);
+    !wait_idle(rafael); // wait the mock to process msgs
     .send(rafael, achieve, goto(10,30));
-    .wait(400);
+    !wait_idle(rafael); // wait the mock to process msgs
     !assert_true(my_position(10,30));
 
     .send(rafael, tell, value(beer,10));
@@ -37,14 +37,17 @@
 @[test]
 +!test_timeout_send
     <-
-    .create_agent(tom);
+    !create_mock_agent(tom);
+
     .send(tom, tellHow, "+?retrieve_info(X,Y) <- .wait(100); Y = X + 1.");
     .send(tom,askOne,retrieve_info(1,Z0),retrieve_info(_,Z0),200); // give enough time to answer
-    .wait(300);
+    !wait_idle(tom); // wait the mock to process msgs
     !assert_equals(2,Z0);
+
     .send(tom,askOne,retrieve_info(10,Z1),Z1,50); // let the timeout expires
-    .wait(300);
+    !wait_idle(tom); // wait the mock to process msgs
     !assert_equals(timeout,Z1);
+
     .kill_agent(tom);
 .
 
@@ -54,7 +57,7 @@
 @[test]
 +!test_kqml_simple_send
     <-
-    .create_agent(maria);
+    !create_mock_agent(maria);
 
     .send(maria, tell, vl(1));
     .send(maria, tell, vl(2));
@@ -63,9 +66,9 @@
     !assert_equals(vl(10)[source(maria)[source(send)]],Z0);
 
     .send(maria, tellHow, "+!goto(X,Y)[source(Ag)] <- .send(Ag, tell, my_position(X,Y)).");
-    .wait(300);
+    !wait_idle(maria); // wait the mock to process msgs
     .send(maria, achieve, goto(10,2));
-    .wait(300);
+    !wait_idle(maria); // wait the mock to process msgs
     !assert_true(my_position(10,30));
 
     // Maria does not believes loves(X,Y)
@@ -95,13 +98,10 @@
           begin)
         }
     );
-    .wait(100);
+    !wait_idle(maria); // wait the mock to process msgs
     .send(maria, achieve, gg);
     .send(maria, askOne, fullname, X3);
     !assert_equals(name("Maria dos Santos")[source(maria)],X3);
-
-    //.send(maria, askAll, Fullname, X4);
-    //.log(warning,"TODO: In .send(maria, askOne, Fullname, X4), X4 is returning vl(10)[source(maria)[source(send)]], it looks like an access violation! X4 = ",X4);
 
     .send(maria, tell, myv(10));
     .send(maria, askOne, myv(_));
@@ -125,13 +125,14 @@
     .send(maria,tellHow,Plan);
     .send(maria, tellHow, "-!hello(Who) <- +failed(Who).");
     .send(maria,achieve,hello(bob));
-    .wait(300); // wait maris to process msgs
+    !wait_idle(maria); // wait the mock to process msgs
     .send(maria,askOne,greeted(bob), W0);
     !assert_equals(greeted(bob)[source(maria)],W0);
     .send(maria,untell,greeted(bob));
 
     // UN-telling how to perform plan +!hello
     .send(maria,untellHow,hp);
+    !wait_idle(maria); // wait the mock to process msgs
     .send(maria,achieve,hello(tom));
     //expected that -!hello was performed
     .send(maria, askOne, greeted(tom), W1);

--- a/src/test/jason/inc/mock_agent.asl
+++ b/src/test/jason/inc/mock_agent.asl
@@ -1,0 +1,22 @@
+/**
+ * A mock agent with mock helpers to be used by tester_agents
+ * The name of the agent that creates the mock is stored in
+ * the belief mock_owner(TesterAgent)
+ */
+
+/**
+ * using default jag_sleeping and jag_awaking to inform
+ * to the mock owner that the agent is sleeping or awake
+ */
+ +jag_sleeping :
+    .my_name(ME) &
+    mock_owner(TAg)
+    <-
+    .send(TAg, tell, sleeping(ME));
+.
+ +jag_awaking :
+    .my_name(ME) &
+    mock_owner(TAg)
+    <-
+    .send(TAg, untell, sleeping(ME));
+.

--- a/src/test/jason/inc/self_tester.asl
+++ b/src/test/jason/inc/self_tester.asl
@@ -17,7 +17,8 @@ tests_passed(0).
 /**
  * Startup operations
  */
-!self_test_asserts.  // tests all asserts both passed and failed conditions
+!self_test_asserts.  // test all asserts both passed and failed conditions
+!self_test_mock_agent. // test the mock agent
 
 /**
  * -!P fail plan to generate assert failure
@@ -109,4 +110,23 @@ tests_passed(0).
     !assert_equals(12,F);
 
     .log(severe,">>> end of self tests.");
+.
+
+/**
+ * Test if the mock agent is sending its sleeping state
+ */
+@[atomic]
++!self_test_mock_agent :
+    .my_name(ME)
+    <-
+    !assert_false(sleeping(mock));
+
+    .create_agent(mock, "mock_agent.asl");
+    .send(mock, tell, mock_owner(ME));
+
+    .wait( not sleeping(mock), 300, _ );
+    .wait( sleeping(mock) );
+
+    !assert_true(sleeping(mock));
+    .kill_agent(mock);
 .

--- a/src/test/jason/inc/test_manager.asl
+++ b/src/test/jason/inc/test_manager.asl
@@ -60,7 +60,12 @@ shutdown_hook.          // shutdown after shutdown_delay(SD), SD is the number o
     <-
     .log(severe,"\n\n");
     .log(severe,"#",N," tests executed, #",P," passed and #",F," failed.");
-    .log(severe,"#",LP," plans launched, #",AP," achieved, at least #",UP," not launched!");
+    if (LP \== AP) {
+        .log(severe,"#",LP," plans launched but only #",AP," achieved!");
+    }
+    if (UP > 0) {
+        .log(severe,"At least #",UP," plan(s) not launched!");
+    }
 
     for (plan_statistics(launched,T,A) & not plan_statistics(achieved,T,A)) {
         .log(severe,"Test '",T,"' was NOT ACHIEVED, agent '",A,"' has FAILED on testing!");


### PR DESCRIPTION
Created mock_agent skeleton which uses default +jag_sleeping and +jag_awaking to tell to the mock_owner when it is sleeping which can be used to assert it is ready to answer to the owner. Hopefully, it is solving the main reason for failures in tests specially in GitHub servers since before it was using arbitrary intervals which sometimes were not enough for the server to do some process and answer as expected.