### PR TITLE
Develop

### DIFF
--- a/src/test/jason/asl/stdlib/broadcast.asl
+++ b/src/test/jason/asl/stdlib/broadcast.asl
@@ -1,0 +1,48 @@
+/**
+ * Test plans for jason internal actions in stdlib
+ *
+ * Most of examples come from Jason's documentation
+ */
+
+{ include("tester_agent.asl") }
+
+@[test]
++!test_broadcast
+    <-
+    !create_mock_agent(jomi);
+
+    .send(jomi, askOne, value(X00), Y00);
+    !assert_false(Y00);
+
+    .broadcast(tell,value(10));
+
+    // This agent should not receive its own message
+    !assert_false(value(10));
+
+    // Ask to the other existing agent, jomi
+    .send(jomi, askOne, value(X), Y0);
+    Y0 = value(Z0)[A0];
+    !assert_equals(10,Z0);
+
+    !create_mock_agent(olivier);
+
+    .send(olivier, askOne, value(Z00));
+    !assert_false(value(10));
+
+    .broadcast(tell,season(summer));
+
+    .send(jomi, askOne, season(X), Y1);
+    Y1 = season(Z1)[source(A1)[source(B1)]];
+    !assert_equals(summer,Z1);
+    !assert_equals(jomi,A1);
+    !assert_equals(broadcast,B1);
+
+    .send(olivier, askOne, season(X), Y2);
+    Y2 = season(Z2)[source(A2)[source(B2)]];
+    !assert_equals(summer,Z2);
+    !assert_equals(olivier,A2);
+    !assert_equals(broadcast,B2);
+
+    .kill_agent(jomi);
+    .kill_agent(olivier);
+.

--- a/src/test/jason/asl/test_failure_event.asl
+++ b/src/test/jason/asl/test_failure_event.asl
@@ -31,6 +31,27 @@
 .
 
 /**
+ * Test constraint failed when trying to unifying something false
+ */
+@[test]
++!test_constraint_failed
+    <-
+    !create_mock_agent(alessandro);
+    .send(alessandro, askOne, value(X10), Y10);
+    Y10 = value(Z10)[source(A10)[source(B10)]];
+    !assert_equals(alessandro,A10);
+    .kill_agent(alessandro);
+.
+-!test_constraint_failed[error(ErrorId), error_msg(Msg), code(CodeBody), code_src(CodeSrc), code_line(CodeLine)]
+   <-
+   //This !check_test_fail_event was created just to performed the asserts below. When the problem is solved it can be removed and asserts uncommented
+   !assert_equals(constraint_failed,ErrorId);
+   !assert_equals("file:./src/test/jason/asl/test_failure_event.asl",CodeSrc);
+
+   .print("Expected error: ", ErrorId, " '",Msg,"' by ",CodeBody," in ",CodeSrc,":",CodeLine);
+.
+
+/**
  * Test generic fail event and ia_failed
  */
 @[test]

--- a/src/test/jason/asl/test_lists.asl
+++ b/src/test/jason/asl/test_lists.asl
@@ -7,13 +7,22 @@
 member(Item, [Item|Tail]).
 //member(Item, [Head|Tail]) :- member(Item,Tail).
 
+l([a,b,c(0),1]).
+a_rule(X,RET) :- l(L) & .reverse(L,LREV) & LREV = [H|T] & RET = H + X.
+another_rule(Y,RET2) :- a_rule(Y,RET) & RET > Y & RET2 = RET.
+
 /**
  * Test
  */
 @[test]
 +!test_lists
     <-
-    [H|T] = [a,b,c(0),1];
+    [HX|TX] = [a,b,c(0),1];
+    !assert_equals(a,HX);
+    !assert_equals([b,c(0),1],TX);
+
+    L = [a,b,c(0),1];
+    L = [H|T];
     !assert_equals(a,H);
     !assert_equals([b,c(0),1],T);
     [a,b,c(0),1] = [Hb|Tb];
@@ -44,4 +53,21 @@ member(Item, [Item|Tail]).
     !assert_true(member(a, [a,b,c]));
     !assert_true(member(c, [a,b,c]));
     !assert_false(member(d, [a,b,c]));
+
+    !test_list_in_context;
+
+    !test_list_in_rules;
+.
+
++!test_list_in_context :
+    L = [a,b,c(0),1] & L = [H|T]
+    <-
+    !assert_equals(a,H);
+    !assert_equals([b,c(0),1],T);
+.
+
++!test_list_in_rules :
+    another_rule(2,R)
+    <-
+    !assert_equals(3,R);
 .

--- a/src/test/jason/inc/test_manager.asl
+++ b/src/test/jason/inc/test_manager.asl
@@ -184,3 +184,15 @@ shutdown_hook.          // shutdown after finishing or shutdown_delay(SD). Defau
     <-
     +plan_statistics(Status,Plan,Agent);
 .
+
+/**
+ * Fatal error informed
+ */
+ @fatal_error
+ +fatal_error
+    <-
+    .log(severe,"\n\n");
+    .log(severe,"Fatal error informed. It is likely to be an error on code/parser!");
+    .log(severe,"No test statistics will be displayed. FAILED!\n\n");
+    .stopMAS(0,1);
+ .

--- a/src/test/jason/inc/tester_agent.asl
+++ b/src/test/jason/inc/tester_agent.asl
@@ -50,9 +50,8 @@ auto_create_fail_plan.  // create -!P fail plan to capture unexpected failures
         -!P[error(E),code(C),code_src(S),code_line(L),error_msg(M)] :
             true
             <-
-            .log(severe,
-                "Error '",E,"' in '",S,"' on event '",C,"' at line ",L," FAILED! Message: '",M,"' Error on code/parser! ",
-                "No test statistics will be displayed.");
+            .log(severe,"Error '",E,"' in '",S,"' on event '",C,"' at line ",L," FAILED! Message: '",M);
+            .send(test_manager,tell,fatal_error);
     }, self, end);
 .
 +!create_default_fail_plan. // Do not create plans if it is disabled


### PR DESCRIPTION
Besides a few more tests, it is fixing an error I have created on commit 4d4651c8247c141d478866608da267fb58f3d22f. There I have removed from a tester_agent the ability to shutdown a system, since it seems reasonable to be something that only test_manager can do. However, there are some fatal_errors such as in code when parsing that are detected by tester agents and it is safer to do not continue on tests since we can't guarantee assertions from this error on.