### PR TITLE
Develop

### DIFF
--- a/src/main/java/jason/stdlib/type.java
+++ b/src/main/java/jason/stdlib/type.java
@@ -1,0 +1,125 @@
+package jason.stdlib;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import jason.asSemantics.DefaultInternalAction;
+import jason.asSemantics.InternalAction;
+import jason.asSemantics.TransitionSystem;
+import jason.asSemantics.Unifier;
+import jason.asSyntax.ASSyntax;
+import jason.asSyntax.Term;
+
+/**
+  <p>Internal action: <b><code>.type</code></b>.
+
+  <p>Description: retrieves types of the argument or checks whether the argument is of a given type.
+
+  <p>Parameter:<ul>
+  <li>+ argument (any term): the term to be checked.<br/>
+  <li>+ type (any term or variable): the given type or a variable to retrieves types.<br/>
+  </ul>
+
+  <p>Examples:<ul>
+  <li> <code>.type(\"home page\",string)</code>: true.
+  <li> <code>.type(b(10),string)</code>: false.
+  <li> <code>.type(b,T)</code>: unifies T with the term 'atom' and backtracks unifying T with 'literal' and 'ground'.
+  <li> <code>.type(X,T)</code>: unifies T with the term 'free' if X is free, or other types if X is not free.
+  </ul>
+
+  @see jason.stdlib.atom
+  @see jason.stdlib.list
+  @see jason.stdlib.literal
+  @see jason.stdlib.number
+  @see jason.stdlib.string
+  @see jason.stdlib.structure
+  @see jason.stdlib.ground
+
+*/
+@Manual(
+        literal=".type(argument,type)",
+        hint="retrieves types of the argument or checks whether the argument is of a given type",
+        argsHint= {
+                "the term to be checked",
+                "the given type or a variable to retrieves types"
+        },
+        argsType= {
+                "term",
+                "term or variable"
+        },
+        examples= {
+                ".type(\"home page\",string): true",
+                ".type(b(10),string): false",
+                ".type(b,T): unifies T with the term 'atom' and backtracks unifying T with 'literal' and 'ground'",
+                ".type(X,T): unifies T with the term 'free' if X is free, or other types if X is not free"
+        },
+        seeAlso= {
+                "jason.stdlib.atom",
+                "jason.stdlib.list",
+                "jason.stdlib.literal",
+                "jason.stdlib.number",
+                "jason.stdlib.string",
+                "jason.stdlib.structure",
+                "jason.stdlib.ground"
+        }
+    )
+@SuppressWarnings("serial")
+public class type extends DefaultInternalAction {
+
+    private static InternalAction singleton = null;
+    public static InternalAction create() {
+        if (singleton == null)
+            singleton = new type();
+        return singleton;
+    }
+
+    @Override public int getMinArgs() {
+        return 2;
+    }
+    @Override public int getMaxArgs() {
+        return 2;
+    }
+
+    @Override
+    public Object execute(TransitionSystem ts, Unifier un, Term[] args) throws Exception {
+        checkArguments(args);
+
+        // It is ordered from the most primitive types to less primitive
+        List<Term> types = new ArrayList<>();
+        if (args[0].isNumeric())    types.add(ASSyntax.createAtom("number"));
+        if (args[0].isAtom())       types.add(ASSyntax.createAtom("atom"));
+        if (args[0].isLiteral())    types.add(ASSyntax.createAtom("literal"));
+        if (args[0].isString())     types.add(ASSyntax.createAtom("string"));
+        if (args[0].isList())       types.add(ASSyntax.createAtom("list"));
+        if (args[0].isSet())        types.add(ASSyntax.createAtom("set"));
+        if (args[0].isGround())     types.add(ASSyntax.createAtom("ground"));
+        if (args[0].isStructure())  types.add(ASSyntax.createAtom("structure"));
+        if (args[0].isVar())        types.add(ASSyntax.createAtom("free"));
+
+        // if it just wants to check whether args[0] is of type args[1]
+        if (!args[1].isVar()) {
+            return types.contains(args[1]);
+        } else {
+            // backtracks all types of args[0]
+            return new Iterator<Unifier>() {
+                int n = 0;
+
+                public boolean hasNext() {
+                    return (n < types.size());
+                }
+
+                public Unifier next() {
+                    Unifier c = un.clone();
+                    
+                    if (types.size() > 0)
+                        c.unifies(args[1], types.get(n++));
+                    
+                    return c;
+                }
+                
+                public void remove() {}
+            };
+        }
+    }
+}

--- a/src/test/jason/asl/stdlib/atom.asl
+++ b/src/test/jason/asl/stdlib/atom.asl
@@ -7,7 +7,7 @@
 { include("tester_agent.asl") }
 
 @[test]
-+!test_string
++!test_atom
     <-
     !assert_false( .atom(b(10)) );
     !assert_true( .atom(b) );

--- a/src/test/jason/asl/stdlib/atom.asl
+++ b/src/test/jason/asl/stdlib/atom.asl
@@ -1,0 +1,29 @@
+/**
+ * Test plans for jason internal actions in stdlib
+ *
+ * Most of examples come from Jason's documentation
+ */
+
+{ include("tester_agent.asl") }
+
+@[test]
++!test_string
+    <-
+    !assert_false( .atom(b(10)) );
+    !assert_true( .atom(b) );
+    !assert_false( .atom(~b) );
+    !assert_false( .atom(10) );
+    !assert_false( .atom("home page") );
+    !assert_false( .atom(X) );
+
+    Y = "a string";
+    !assert_false( .atom(Y) );
+
+    Z = atom;
+    !assert_true( .atom(Z) );
+
+    !assert_false( .atom(a(X)) );
+    !assert_false( .atom(a[X]) );
+    !assert_false( .atom([a,b,c]) );
+    !assert_false( .atom([a,b,c(X)]) );
+.

--- a/src/test/jason/asl/stdlib/ground.asl
+++ b/src/test/jason/asl/stdlib/ground.asl
@@ -1,0 +1,29 @@
+/**
+ * Test plans for jason internal actions in stdlib
+ *
+ * Most of examples come from Jason's documentation
+ */
+
+{ include("tester_agent.asl") }
+
+@[test]
++!test_ground
+    <-
+    !assert_true( .ground(b(10)) );
+    !assert_true( .ground(b) );
+    !assert_true( .ground(~b) );
+    !assert_true( .ground(10) );
+    !assert_true( .ground("home page") );
+    !assert_false( .ground(X) );
+
+    Y = "a string";
+    !assert_true( .ground(Y) );
+
+    Z = atom;
+    !assert_true( .ground(Z) );
+
+    !assert_false( .ground(a(X)) );
+    !assert_false( .ground(a[X]) );
+    !assert_true( .ground([a,b,c]) );
+    !assert_false( .ground([a,b,c(X)]) );
+.

--- a/src/test/jason/asl/stdlib/list.asl
+++ b/src/test/jason/asl/stdlib/list.asl
@@ -1,0 +1,25 @@
+/**
+ * Test plans for jason internal actions in stdlib
+ *
+ * Most of examples come from Jason's documentation
+ */
+
+{ include("tester_agent.asl") }
+
+@[test]
++!test_list
+    <-
+    !assert_true( .list([a,b,c]) );
+    !assert_true( .list([a,b,c(X)]) );
+    !assert_false( .list(10) );
+    !assert_false( .list("home page") );
+    !assert_false( .list(X) );
+
+    Y = "a string";
+    !assert_false( .list(Y) );
+
+    Z = [];
+    !assert_true( .list(Z) );
+
+    !assert_false( .list(a(X)) );
+.

--- a/src/test/jason/asl/stdlib/literal.asl
+++ b/src/test/jason/asl/stdlib/literal.asl
@@ -1,0 +1,27 @@
+/**
+ * Test plans for jason internal actions in stdlib
+ *
+ * Most of examples come from Jason's documentation
+ */
+
+{ include("tester_agent.asl") }
+
+@[test]
++!test_literal
+    <-
+    !assert_true( .literal(b(10)) );
+    !assert_true( .literal(b) );
+    !assert_false( .literal(10) );
+    !assert_false( .literal("Jason") );
+    !assert_false( .literal(X) );
+
+    Y = "a string";
+    !assert_false( .literal(Y) );
+
+    Z = atom;
+    !assert_true( .literal(Z) );
+
+    !assert_true( .literal(a(X)) );
+    !assert_false( .literal([a,b,c]) );
+    !assert_false( .literal([a,b,c(X)]) );
+.

--- a/src/test/jason/asl/stdlib/number.asl
+++ b/src/test/jason/asl/stdlib/number.asl
@@ -1,0 +1,27 @@
+/**
+ * Test plans for jason internal actions in stdlib
+ *
+ * Most of examples come from Jason's documentation
+ */
+
+{ include("tester_agent.asl") }
+
+@[test]
++!test_number
+    <-
+    !assert_false( .number(b(10)) );
+    !assert_false( .number(b) );
+    !assert_false( .number(~b) );
+    !assert_true( .number(10) );
+    !assert_false( .number("home page") );
+    !assert_false( .number(X) );
+
+    Y = "a string";
+    !assert_false( .number(Y) );
+
+    Z = -400;
+    !assert_true( .number(Z) );
+
+    !assert_false( .number(a(X)) );
+    !assert_false( .number([1,2]) );
+.

--- a/src/test/jason/asl/stdlib/string.asl
+++ b/src/test/jason/asl/stdlib/string.asl
@@ -1,0 +1,22 @@
+/**
+ * Test plans for jason internal actions in stdlib
+ *
+ * Most of examples come from Jason's documentation
+ */
+
+{ include("tester_agent.asl") }
+
+@[test]
++!test_string
+    <-
+    !assert_true( .string("home page") );
+    !assert_false( .string(b(10)) );
+    !assert_false( .string(b) );
+    !assert_false( .string(X) );
+
+    Y = "a string";
+    !assert_true( .string(Y) );
+
+    Z = atom;
+    !assert_false( .string(Z) );
+.

--- a/src/test/jason/asl/stdlib/structure.asl
+++ b/src/test/jason/asl/stdlib/structure.asl
@@ -1,0 +1,28 @@
+/**
+ * Test plans for jason internal actions in stdlib
+ *
+ * Most of examples come from Jason's documentation
+ */
+
+{ include("tester_agent.asl") }
+
+@[test]
++!test_structure
+    <-
+    !assert_true( .structure(b(10)) );
+    .log(warning,"TODO: .structure(b) is supposed to be true!")
+    //!assert_true( .structure(b) );
+    !assert_false( .structure(10) );
+    !assert_false( .structure("home page") );
+    !assert_false( .structure(X) );
+
+    Y = "a string";
+    !assert_false( .structure(Y) );
+
+    Z = atom;
+    !assert_true( .structure(Z) );
+
+    !assert_true( .structure(a(X)) );
+    !assert_true( .structure([a,b,c]) );
+    !assert_true( .structure([a,b,c(X)]) );
+.

--- a/src/test/jason/asl/stdlib/type.asl
+++ b/src/test/jason/asl/stdlib/type.asl
@@ -1,0 +1,280 @@
+/**
+ * Test plans for jason internal actions in stdlib
+ *
+ * Most of examples come from Jason's documentation
+ */
+
+{ include("tester_agent.asl") }
+
+@[test]
++!test_type_string
+    <-
+    /* check strings */
+    !assert_true( .type("home page",string) );
+    !assert_false( .type(b(10),string) );
+    !assert_false( .type(b,string) );
+    !assert_false( .type(X,string) );
+    Y = "a string";
+    !assert_true( .type(Y,string) );
+    Z = atom;
+    !assert_false( .type(Z,string) );
+
+    /* unifying as strings */
+    .type("home page",T0_0);
+    !assert_equals(string,T0_0);
+    .type(b(10),T0_1);
+    !assert_not_equals(string,T0_1);
+    .type(b,T0_2);
+    !assert_not_equals(string,T0_2);
+
+    .findall(T0_3,.type(X,T0_3),L0_3);
+    !assert_not_contains(L0_3,string);
+
+    .type(Y,T0_4);
+    !assert_equals(string,T0_4);
+    .type(Z,T0_5);
+    !assert_not_equals(string,T0_5);
+.
+
+@[test]
++!test_type_atom
+    <-
+    /* check strings */
+    !assert_false( .type(b(10),atom) );
+    !assert_true( .type(b,atom) );
+    !assert_false( .type(~b,atom) );
+    !assert_false( .type(10,atom) );
+    !assert_false( .type("home page",atom) );
+    !assert_false( .type(X,atom) );
+
+    Y = "a string";
+    !assert_false( .type(Y,atom) );
+
+    Z = atom;
+    !assert_true( .type(Z,atom) );
+
+    !assert_false( .type(a(X),atom) );
+    !assert_false( .type(a[X],atom) );
+    !assert_false( .type([a,b,c],atom) );
+    !assert_false( .type([a,b,c(X)],atom) );
+
+    /* unifying as atom */
+    .type(b(10),T0);
+    !assert_not_equals(atom,T0);
+    .type(b,T1);
+    !assert_equals(atom,T1);
+    .type(~b,T2);
+    !assert_not_equals(atom,T2);
+    .type(10,T3);
+    !assert_not_equals(atom,T3);
+    .type("home page",T4);
+    !assert_not_equals(atom,T4);
+    .type(X,T5);
+    !assert_not_equals(atom,T5);
+
+    .type(Y,T6);
+    !assert_not_equals(atom,T6);
+
+    .type(Z,T7);
+    !assert_equals(atom,T7);
+
+    .type(a(X),T8);
+    !assert_not_equals(atom,T8);
+    .type(a[X],T9);
+    !assert_not_equals(atom,T9);
+    .type([a,b,c],T10);
+    !assert_not_equals(atom,T10);
+    .type([a,b,c(X)],T11);
+    !assert_not_equals(atom,T11);
+.
+
+@[test]
++!test_typeof_literal
+    <-
+    !assert_true( .type(b(10),literal) );
+    !assert_true( .type(b,literal) );
+    !assert_true( .type(~b,literal) );
+    !assert_false( .type(10,literal) );
+    !assert_false( .type("Jason",literal) );
+    !assert_false( .type(X,literal) );
+
+    Y = "a string";
+    !assert_false( .type(Y,literal) );
+
+    Z = atom;
+    !assert_true( .type(Z,literal) );
+
+    !assert_true( .type(a(X),literal) );
+    !assert_false( .type([a,b,c],literal) );
+    !assert_false( .type([a,b,c(X)],literal) );
+
+    /* unifying as string */
+    .type(b(10),T0);
+    !assert_equals(literal,T0);
+
+    // This case needs backtracking
+    .findall(T1, .type(b,T1) ,L1);
+    !assert_contains(L1,literal);
+
+    .type(~b,T2);
+    !assert_equals(literal,T2);
+    .type(10,T3);
+    !assert_not_equals(literal,T3);
+    .type("home page",T4);
+    !assert_not_equals(literal,T4);
+    .type(X,T5);
+    !assert_not_equals(literal,T5);
+
+    .type(Y,T6);
+    !assert_not_equals(literal,T6);
+
+    // This case needs backtracking
+    .findall(T7, .type(b,T7) ,L7);
+    !assert_contains(L7,literal);
+
+    .type(a(X),T8);
+    !assert_equals(literal,T8);
+    .type(a[X],T9);
+    !assert_equals(literal,T9);
+    .type([a,b,c],T10);
+    !assert_not_equals(literal,T10);
+    .type([a,b,c(X)],T11);
+    !assert_not_equals(literal,T11);
+.
+
+
+@[test]
++!test_type_list
+    <-
+    !assert_true( .type([a,b,c],list) );
+    !assert_true( .type([a,b,c(X)],list) );
+    !assert_false( .type(10,list) );
+    !assert_false( .type("home page",list) );
+    !assert_false( .type(X,list) );
+
+    Y = "a string";
+    !assert_false( .type(Y,list) );
+
+    Z = [];
+    !assert_true( .type(Z,list) );
+
+    !assert_false( .type(a(X),list) );
+
+    /* unifying as list */
+    .type([a,b,c],T0);
+    !assert_equals(list,T0);
+    .type([a,b,c(X)],T1);
+    !assert_equals(list,T1);
+    .type(10,T2);
+    !assert_not_equals(list,T2);
+    .type("home page",T3);
+    !assert_not_equals(list,T3);
+    .type(X,T4);
+    !assert_not_equals(list,T4);
+
+    .type(Y,T5);
+    !assert_not_equals(list,T5);
+
+    .type(Z,T6);
+    !assert_equals(list,T6);
+
+    .type(a(X),T7);
+    !assert_not_equals(list,T7);
+.
+
+@[test]
++!test_type_ground
+    <-
+    !assert_true( .type(b(10),ground) );
+    !assert_true( .type(b,ground) );
+    !assert_true( .type(~b,ground) );
+    !assert_true( .type(10,ground) );
+    !assert_true( .type("home page",ground) );
+    !assert_false( .type(X,ground) );
+
+    Y = "a string";
+    !assert_true( .type(Y,ground) );
+
+    Z = atom;
+    !assert_true( .type(Z,ground) );
+
+    !assert_false( .type(a(X),ground) );
+    !assert_false( .type(a[X],ground) );
+    !assert_true( .type([a,b,c],ground) );
+    !assert_false( .type([a,b,c(X)],ground) );
+
+    /* unifying as ground - many case needs backtracking*/
+
+    .findall(T0, .type(b(10),T0) ,L0);
+    !assert_contains(L0,ground);
+
+    .findall(T1, .type(b,T1) ,L1);
+    !assert_contains(L1,ground);
+    .findall(T2, .type(~b,T2) ,L2);
+    !assert_contains(L2,ground);
+    .findall(T3, .type(10,T3) ,L3);
+    !assert_contains(L3,ground);
+    .findall(T4, .type("home page",T4) ,L4);
+    !assert_contains(L4,ground);
+    .findall(T5, .type(X,T5) ,L5);
+    !assert_not_contains(L5,ground);
+
+    .findall(T6, .type(Y,T6) ,L6);
+    !assert_contains(L6,ground);
+
+    .findall(T7, .type(Z,T7) ,L7);
+    !assert_contains(L7,ground);
+
+    .type(a(X),T8)
+    !assert_not_equals(ground,T8);
+    .type(a[X],T9);
+    !assert_not_equals(ground,T9);
+    .findall(T10, .type([a,b,c],T10) ,L10);
+    !assert_contains(L10,ground);
+    .type([a,b,c(X)],T11);
+    !assert_not_equals(ground,T11);
+.
+
+@[test]
++!test_number
+    <-
+    !assert_false( .type(b(10),number) );
+    !assert_false( .type(b,number) );
+    !assert_false( .type(~b,number) );
+    !assert_true( .type(10,number) );
+    !assert_false( .type("home page",number) );
+    !assert_false( .type(X,number) );
+
+    Y = "a string";
+    !assert_false( .type(Y,number) );
+
+    Z = -400;
+    !assert_true( .type(Z,number) );
+
+    !assert_false( .type(a(X),number) );
+    !assert_false( .type([1,2],number) );
+
+    .type(b(10),T0);
+    !assert_not_equals(number,T0);
+    .type(b,T1);
+    !assert_not_equals(number,T1);
+    .type(~b,T2);
+    !assert_not_equals(number,T2);
+    .type(10,T3);
+    !assert_equals(number,T3);
+    .type("home page",T4);
+    !assert_not_equals(number,T4);
+    .type(X,T5);
+    !assert_not_equals(number,T5);
+
+    .type(Y,T6)
+    !assert_not_equals(number,T6);
+
+    .type(Z,T7);
+    !assert_equals(number,T7);
+
+    .type(a(X),T8)
+    !assert_not_equals(number,T8);
+    .type([1,2],T9);
+    !assert_not_equals(number,T9);
+.

--- a/src/test/jason/inc/test_assert.asl
+++ b/src/test/jason/inc/test_assert.asl
@@ -213,6 +213,13 @@ intention_test_goal(Goal,Test,Label,Line,Src) :- .intention(ID,_,[ im(Label,TGoa
  */
 @assert_contains[atomic]
 +!assert_contains(X,Y) :
+    intention_test_goal(Goal,Test,Label,Line,Src) &
+    .findall(T, .type(X,T) ,Types) & not .member(list,Types) & not .member(set,Types) 
+    <-
+    .log(severe,"assert_contains expecting '",Y,"' in '",X,"' could not be performed since '",X,"' must be a list or a set. FAILED!");
+    .fail;
+.
++!assert_contains(X,Y) :
     intention_test_goal(Goal,Test,Label,Line,Src)
     <-
     if (not .member(Y,X)) {
@@ -236,6 +243,13 @@ intention_test_goal(Goal,Test,Label,Line,Src) :- .intention(ID,_,[ im(Label,TGoa
  * Asserts if X does not contain Y
  */
 @assert_not_contains[atomic]
++!assert_not_contains(X,Y) :
+    intention_test_goal(Goal,Test,Label,Line,Src) &
+    .findall(T, .type(X,T) ,Types) & not .member(list,Types) & not .member(set,Types)
+    <-
+    .log(severe,"assert_not_contains expecting '",Y,"' NOT in '",X,"' could not be performed since '",X,"' must be a list or a set. FAILED!");
+    .fail;
+.
 +!assert_not_contains(X,Y) :
     intention_test_goal(Goal,Test,Label,Line,Src)
     <-

--- a/src/test/jason/inc/test_assert.asl
+++ b/src/test/jason/inc/test_assert.asl
@@ -16,7 +16,9 @@ intention_test_goal(Goal,Test,Label,Line,Src) :- .intention(ID,_,[ im(Label,TGoa
     not .list(X) & not .list(Y)
     <-
     if (X \== Y) {
-        .log(severe,"assert_equals on event '",Goal,"' starting at line ",Line," FAILED! Expected ",X," but had ",Y);
+        .type(X,TX);
+        .type(Y,TY);
+        .log(severe,"assert_equals on event '",Goal,"' starting at line ",Line," FAILED! Expected '",X,"' (",TX,") but had '",Y,"' (",TY,")");
         .fail;
     } else {
         +test(Test,passed,Src,Line)[assert_equals(X,Y)];
@@ -26,29 +28,31 @@ intention_test_goal(Goal,Test,Label,Line,Src) :- .intention(ID,_,[ im(Label,TGoa
 +!assert_equals(X,Y) : // compare lists
     intention_test_goal(Goal,Test,Label,Line,Src)
     <-
-    for (.member(Xth,X)) {
-        if (not .member(Xth,Y)) {
-            .log(severe,"assert_equals on event '",Goal,"' starting at line ",Line," FAILED! Expected ",X," but had ",Y);
+    .type(X,TX);
+    .type(Y,TY);
+    for ( .member(Xth,X) ) {
+        if ( not .member(Xth,Y) ) {
+            .log(severe,"assert_equals on event '",Goal,"' starting at line ",Line," FAILED! Expected '",X,"' (",TX,") but had '",Y,"' (",TY,")");
             .fail;
         }
     }
-    for (.member(Yth,Y)) {
-        if (not .member(Yth,X)) {
-            .log(severe,"assert_equals on event '",Goal,"' starting at line ",Line," FAILED! Expected ",X," but had ",Y);
+    for ( .member(Yth,Y) ) {
+        if ( not .member(Yth,X) ) {
+            .log(severe,"assert_equals on event '",Goal,"' starting at line ",Line," FAILED! Expected '",X,"' (",TX,") but had '",Y,"' (",TY,")");
             .fail;
         }
     }
     +test(Test,passed,Src,Line)[assert_equals(X,Y)];
     .log(info,"assert_equals on event '",Goal,"' PASSED");
 .
-+!assert_equals(X,Y) :
-    true
++!assert_equals(X,Y)
     <-
-    .log(severe,"assert_equals on event 'unknown' FAILED! Expected ",X," but had ",Y);
+    .type(X,TX);
+    .type(Y,TY);
+    .log(severe,"assert_equals expecting '",X,"' (",TX,") and having '",Y,"' (",TY,") could not be performed! FAILED!");
     .fail;
 .
--!assert_equals(X,Y) :
-    true
+-!assert_equals(X,Y)
     <-
     +test(Test,failed,Src,Line)[assert_equals(X,Y)];
 .
@@ -61,24 +65,57 @@ intention_test_goal(Goal,Test,Label,Line,Src) :- .intention(ID,_,[ im(Label,TGoa
 +!assert_equals(X,Y,T) :
     intention_test_goal(Goal,Test,Label,Line,Src)
     <-
+    .type(X,TX);
+    .type(Y,TY);
     if (not (Y >= X-T & Y <= X+T)) {
-        .log(severe,"assert_equals on event '",Goal,"' starting at line ",Line," FAILED! Expected ",X,"+/-",T,", but had ",Y);
+        .log(severe,"assert_equals on event '",Goal,"' starting at line ",Line," FAILED! Expected '",X,"+/-",T,"' (",TX,"), but had '",Y,"' (",TY,")");
         .fail;
     } else {
         +test(Test,passed,Src,Line)[assert_equals(X,Y,T)];
         .log(info,"assert_equals on event '",Goal,"' PASSED");
     }
 .
-+!assert_equals(X,Y,T) :
-    true
++!assert_equals(X,Y,T)
     <-
-    .log(severe,"assert_equals on event 'unknown' FAILED! Expected ",X,"+/-",T,", but had ",Y);
+    .type(X,TX);
+    .type(Y,TY);
+    .log(severe,"assert_equals expecting '",X,"+/-",T,"' (",TX,") and having '",Y,"' (",TY,") could not be performed! FAILED!");
     .fail;
 .
--!assert_equals(X,Y,T) :
-    true
+-!assert_equals(X,Y,T)
     <-
     +test(Test,failed,Src,Line)[assert_equals(X,Y,T)];
+.
+
+/**
+ * Asserts if X is not equals to Y
+ * IMPORTANT! Do no use this method to compare float numbers
+ */
+@assert_not_equals[atomic]
++!assert_not_equals(X,Y) : // compare terms
+    intention_test_goal(Goal,Test,Label,Line,Src) &
+    not .list(X) & not .list(Y)
+    <-
+    .type(X,TX);
+    .type(Y,TY);
+    if (X == Y) {
+        .log(severe,"assert_not_equals on event '",Goal,"' starting at line ",Line," FAILED! Expected '",X,"' (",TX,") different than '",Y,"' (",TY,")");
+        .fail;
+    } else {
+        +test(Test,passed,Src,Line)[assert_equals(X,Y)];
+        .log(info,"assert_not_equals on event '",Goal,"' PASSED");
+    }
+.
++!assert_not_equals(X,Y)
+    <-
+    .type(X,TX);
+    .type(Y,TY);
+    .log(severe,"assert_not_equals expecting '",X,"' (",TX,") and having '",Y,"' (",TY,") could not be performed! FAILED!");
+    .fail;
+.
+-!assert_not_equals(X,Y)
+    <-
+    +test(Test,failed,Src,Line)[assert_not_equals(X,Y)];
 .
 
 /**
@@ -89,21 +126,19 @@ intention_test_goal(Goal,Test,Label,Line,Src) :- .intention(ID,_,[ im(Label,TGoa
     intention_test_goal(Goal,Test,Label,Line,Src)
     <-
     if (not X) {
-        .log(severe,"assert_true on event '",Goal,"' starting at line ",Line," FAILED! Expected ",X);
+        .log(severe,"assert_true on event '",Goal,"' starting at line ",Line," FAILED! Expected '",X,"'");
         .fail;
     } else {
         .log(info,"assert_true on event '",Goal,"' PASSED");
         +test(Test,passed,Src,Line)[assert_true(X)];
     }
 .
-+!assert_true(X) :
-    true
++!assert_true(X)
     <-
-    .log(severe,"assert_true on event 'unknown' FAILED! Expected ",X);
+    .log(severe,"assert_true expecting '",X,"' could not be performed! FAILED!");
     .fail;
 .
--!assert_true(X) :
-    true
+-!assert_true(X)
     <-
     +test(Test,failed,Src,Line)[assert_true(X)];
 .
@@ -116,21 +151,19 @@ intention_test_goal(Goal,Test,Label,Line,Src) :- .intention(ID,_,[ im(Label,TGoa
     intention_test_goal(Goal,Test,Label,Line,Src)
     <-
     if (X) {
-        .log(severe,"assert_false on event '",Goal,"' starting at line ",Line," FAILED! Expected not ",X);
+        .log(severe,"assert_false on event '",Goal,"' starting at line ",Line," FAILED! Expected 'not ",X,"'");
         .fail;
     } else {
         +test(Test,passed,Src,Line)[assert_false(X)];
         .log(info,"assert_false on event '",Goal,"' PASSED");
     }
 .
-+!assert_false(X) :
-    true
++!assert_false(X)
     <-
-    .log(severe,"assert_false on event 'unknown' FAILED! Expected not ",X);
+    .log(severe,"assert_false expecting 'not ",X,"' could not be performed! FAILED!");
     .fail;
 .
--!assert_false(X) :
-    true
+-!assert_false(X)
     <-
     +test(Test,failed,Src,Line)[assert_false(X)];
 .
@@ -145,14 +178,12 @@ intention_test_goal(Goal,Test,Label,Line,Src) :- .intention(ID,_,[ im(Label,TGoa
     +test(Test,passed,Src,Line)[force_pass];
     .log(info,"force_pass on event '",Goal,"' PASSED");
 .
-+!force_pass :
-    true
++!force_pass
     <-
-    .log(severe,"force_pass on event 'unknown' FAILED!");
+    .log(severe,"force_pass could not be performed properly! FAILED!");
     .fail;
 .
--!force_pass : // Only pass if not applicable
-    true
+-!force_pass // Only pass if not applicable
     <-
     +test(Test,failed,Src,Line)[force_pass];
 .
@@ -164,17 +195,15 @@ intention_test_goal(Goal,Test,Label,Line,Src) :- .intention(ID,_,[ im(Label,TGoa
 +!force_failure(MSG) :
     intention_test_goal(Goal,Test,Label,Line,Src)
     <-
-    .log(severe,"force_failure on event '",Goal,"' forcedly FAILED! Msg: ",MSG);
+    .log(severe,"force_failure on event '",Goal,"' forcedly FAILED! Msg: '",MSG,"'");
     .fail;
 .
-+!force_failure(MSG) :
-    true
++!force_failure(MSG)
     <-
-    .log(severe,"force_failure on event 'unknown' FAILED!");
+    .log(severe,"force_failure could not be performed properly! FAILED!");
     .fail;
 .
--!force_failure(MSG) : // Only failure if not applicable
-    true
+-!force_failure(MSG) // Only failure if not applicable
     <-
     +test(Test,failed,Src,Line)[force_failure];
 .
@@ -187,20 +216,18 @@ intention_test_goal(Goal,Test,Label,Line,Src) :- .intention(ID,_,[ im(Label,TGoa
     intention_test_goal(Goal,Test,Label,Line,Src)
     <-
     if (not .member(Y,X)) {
-        .log(severe,"assert_contains on event '",Goal,"' starting at line ",Line," FAILED! Expected ",Y," in ",X);
+        .log(severe,"assert_contains on event '",Goal,"' starting at line ",Line," FAILED! Expected '",Y,"' in '",X,"'");
         .fail;
     }
     +test(Test,passed,Src,Line)[assert_contains(X,Y)];
     .log(info,"assert_contains on event '",Goal,"' PASSED");
 .
-+!assert_contains(X,Y) :
-    true
++!assert_contains(X,Y)
     <-
-    .log(severe,"assert_contains on event 'unknown' FAILED! Expected ",Y," in ",X);
+    .log(severe,"assert_contains expecting '",Y,"' in '",X,"' could not be performed! FAILED!");
     .fail;
 .
--!assert_contains(X,Y) :
-    true
+-!assert_contains(X,Y)
     <-
     +test(Test,failed,Src,Line)[assert_contains(X,Y)];
 .
@@ -213,20 +240,18 @@ intention_test_goal(Goal,Test,Label,Line,Src) :- .intention(ID,_,[ im(Label,TGoa
     intention_test_goal(Goal,Test,Label,Line,Src)
     <-
     if ( .member(Y,X) ) {
-        .log(severe,"assert_not_contains on event '",Goal,"' starting at line ",Line," FAILED! Expected ",Y," NOT in ",X);
+        .log(severe,"assert_not_contains on event '",Goal,"' starting at line ",Line," FAILED! Expected '",Y,"' NOT in '",X,"'");
         .fail;
     }
     +test(Test,passed,Src,Line)[assert_not_contains(X,Y)];
     .log(info,"assert_not_contains on event '",Goal,"' PASSED");
 .
-+!assert_not_contains(X,Y) :
-    true
++!assert_not_contains(X,Y)
     <-
-    .log(severe,"assert_not_contains on event 'unknown' FAILED! Expected ",Y," NOT in ",X);
+    .log(severe,"assert_not_contains expecting '",Y,"' NOT in '",X,"' could not be performed! FAILED!");
     .fail;
 .
--!assert_not_contains(X,Y) :
-    true
+-!assert_not_contains(X,Y)
     <-
     +test(Test,failed,Src,Line)[assert_not_contains(X,Y)];
 .
@@ -239,12 +264,17 @@ intention_test_goal(Goal,Test,Label,Line,Src) :- .intention(ID,_,[ im(Label,TGoa
     .number(X) & .number(Y)
     <-
     if (X <= Y) {
-        .log(severe,"assert_greater_than on event '",Goal,"' starting at line ",Line," FAILED! Expected ",X," > ",Y);
+        .log(severe,"assert_greater_than on event '",Goal,"' starting at line ",Line," FAILED! Expected '",X," > ",Y,"'");
         .fail;
     } else {
         +test(Test,passed,Src,Line)[assert_greater_than(X,Y)];
         .log(info,"assert_greater_than on event '",Goal,"' PASSED");
     }
+.
++!assert_greater_than(X,Y)
+    <-
+    .log(severe,"assert_greater_than expecting '",X," > ",Y,"' could not be performed! FAILED!");
+    .fail;
 .
 -!assert_greater_than(X,Y)
     <-
@@ -260,12 +290,17 @@ intention_test_goal(Goal,Test,Label,Line,Src) :- .intention(ID,_,[ im(Label,TGoa
     .number(X) & .number(Y)
     <-
     if (X < Y) {
-        .log(severe,"assert_greater_than_equals on event '",Goal,"' starting at line ",Line," FAILED! Expected ",X," > ",Y);
+        .log(severe,"assert_greater_than_equals on event '",Goal,"' starting at line ",Line," FAILED! Expected '",X," >= ",Y,"'");
         .fail;
     } else {
         +test(Test,passed,Src,Line)[assert_greater_than_equals(X,Y)];
         .log(info,"assert_greater_than_equals on event '",Goal,"' PASSED");
     }
+.
++!assert_greater_than_equals(X,Y)
+    <-
+    .log(severe,"assert_greater_than_equals expecting '",X," >= ",Y,"' could not be performed! FAILED!");
+    .fail;
 .
 -!assert_greater_than_equals(X,Y)
     <-
@@ -278,12 +313,17 @@ intention_test_goal(Goal,Test,Label,Line,Src) :- .intention(ID,_,[ im(Label,TGoa
     .number(X) & .number(Y0) & .number(Y1)
     <-
     if ((X < Y0) | (X > Y1)) {
-        .log(severe,"assert_between on event '",Goal,"' starting at line ",Line," FAILED! Expected ",Y0," <= ",X," <= ",Y1);
+        .log(severe,"assert_between on event '",Goal,"' starting at line ",Line," FAILED! Expected '",Y0," <= ",X," <= ",Y1,"'");
         .fail;
     } else {
         +test(Test,passed,Src,Line)[assert_between(X,Y0,Y1)];
         .log(info,"assert_between on event '",Goal,"' PASSED");
     }
+.
++!assert_between(X,Y0,Y1)
+    <-
+    .log(severe,"assert_between expecting '",Y0," <= ",X," <= ",Y1,"' could not be performed! FAILED!");
+    .fail;
 .
 -!assert_between(X,Y0,Y1)
     <-


### PR DESCRIPTION
Created tests some meta programming internal actions and created a new internal action called .type/2. I t checks whether a term is of a given type or retrieves all the types of the types of term by backtracking them. 
E.g.: .type("home page",string) returns true, .type(b,T) unifies T with the term 'atom' and backtracks unifying T with 'literal' and 'ground'.

The approach backtrack was preferred instead of always return the list of types because it seems to be better at least for producing error messages when types do not match. For instance, let us say the programmer was struggling expecting X == Y, but X == "string" and Y == string. In this case, notice that X is a string but Y is an atom. In this case, .type(X,TX) unifies TX with string which is the most "primitive" type of X. But also backtracks ground. .type(Y,TY) unifies TY with atom which is the most "primitive" type of Y, also backtracks ground. So, it is easier to give to the programmer the most primitive type instead of a list. In case of a list is preferred, a .findall can be used, e.g. .findall(T, .type(X,TX) ,TypesOfX).