### PR TITLE
Add double-buffering to GridWorld view

### DIFF
--- a/examples/blocks-world/BlocksEnv/WorldModel.java
+++ b/examples/blocks-world/BlocksEnv/WorldModel.java
@@ -7,6 +7,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Stack;
 import java.util.logging.Logger;
+import javax.swing.SwingUtilities;
 
 public class WorldModel extends GridWorldModel {
 
@@ -91,7 +92,9 @@ public class WorldModel extends GridWorldModel {
         }
         modelToGrid();
         if (view != null)
-            view.update();
+            SwingUtilities.invokeLater(() -> {
+                view.update();
+            });
 
         return true;
     }
@@ -155,16 +158,16 @@ public class WorldModel extends GridWorldModel {
     void modelToGrid() {
         for (int i=0; i<GWidth; i++) {
             for (int j=0; j<GHeight-1; j++) {
-                model.data[i][j] = 0;
+                model.set(0, i, j);
                 model.names[i][j] = "";
             }
-            model.data[i][GHeight-1] = TABLE;
+            model.set(TABLE, i, GHeight-1);
             model.names[i][GHeight-1] = "table";
         }
         int i=0;
         for (Stack<String> s : stackList) {
             for (int j=1; j<s.size(); j++) {
-                model.data[i*2+1][GHeight-j-1] = BLOCK;
+                model.set(BLOCK, i*2+1, GHeight-j-1);
                 model.names[i*2+1][GHeight-j-1] = s.get(j);
             }
             i++;

--- a/jason-interpreter/src/main/java/jason/environment/grid/GridWorldModel.java
+++ b/jason-interpreter/src/main/java/jason/environment/grid/GridWorldModel.java
@@ -1,5 +1,6 @@
 package jason.environment.grid;
 
+import javax.swing.*;
 import java.util.Random;
 
 
@@ -110,7 +111,10 @@ public class GridWorldModel {
 
     public void set(int value, int x, int y) {
         data[x][y] = value;
-        if (view != null) view.update(x,y);
+        if (view != null) {
+            final int ux = x, uy = y;
+            SwingUtilities.invokeLater(() -> view.update(ux, uy));
+        }
     }
 
     public void add(int value, Location l) {
@@ -119,7 +123,10 @@ public class GridWorldModel {
 
     public void add(int value, int x, int y) {
         data[x][y] |= value;
-        if (view != null) view.update(x,y);
+        if (view != null) {
+            final int ux = x, uy = y;
+            SwingUtilities.invokeLater(() -> view.update(ux, uy));
+        }
     }
 
     public void addWall(int x1, int y1, int x2, int y2) {
@@ -130,13 +137,16 @@ public class GridWorldModel {
         }
     }
 
-    public void remove(int value, Location l) {
+        public void remove(int value, Location l) {
         remove(value, l.x, l.y);
     }
 
     public void remove(int value, int x, int y) {
         data[x][y] &= ~value;
-        if (view != null) view.update(x,y);
+        if (view != null) {
+            final int ux = x, uy = y;
+            SwingUtilities.invokeLater(() -> view.update(ux, uy));
+        }
     }
 
     public void removeAll(int value) {


### PR DESCRIPTION
Fixes GridWorldView flashing on repaint by adding a buffer to the canvas and updating the entire canvas at once.

[before.webm](https://github.com/user-attachments/assets/6419b999-195e-422b-86dc-89ae141d793b)

[after.webm](https://github.com/user-attachments/assets/68436d8f-22e4-4f3a-9420-ea2b91eb918f)
