### PR TITLE
Fix MASConsoleGUI potentially locking up

### DIFF
--- a/jason-interpreter/src/main/java/jason/runtime/MASConsoleColorGUI.java
+++ b/jason-interpreter/src/main/java/jason/runtime/MASConsoleColorGUI.java
@@ -105,19 +105,20 @@ public class MASConsoleColorGUI extends MASConsoleGUI {
             }
 
             // print in output
-            synchronized (output) {
+            Color finalC = c;
+            SwingUtilities.invokeAndWait(() -> {
                 if (output.getDocument().getLength() > 60000) {
                     cleanConsole();
                 }
                 try {
-                    output.append(c, s);
+                    output.append(finalC, s);
                 } catch (Throwable e) {
                     // just try again once...
                     try {
-                        output.append(c, s);
+                        output.append(finalC, s);
                     } catch (Throwable e2) { }
                 }
-            }
+            });
         } catch (InterruptedException e) {
             // ignore, system going down
         } catch (Exception e) {

--- a/jason-interpreter/src/main/java/jason/runtime/MASConsoleGUI.java
+++ b/jason-interpreter/src/main/java/jason/runtime/MASConsoleGUI.java
@@ -191,15 +191,14 @@ public class MASConsoleGUI {
             }
 
             // print in output
-            synchronized (output) {
-                try {
+            try {
+                SwingUtilities.invokeAndWait(() -> {
                     if (output.getDocument().getLength() > 60000) {
                         cleanConsole();
                     }
                     output.append(s);
-                } catch (IllegalArgumentException e) {
-                }
-            }
+                });
+            }  catch (InterruptedException e) {}
         } catch (Exception e) {
             try {
                 PrintWriter out = new PrintWriter(new FileWriter("e_r_r_o_r.txt"));


### PR DESCRIPTION
Hi,
Recently, I suddenly couldn't run any MAS without it freezing within a few seconds. (Not entirely sure what caused it, maybe my JDK updated.. I am using Jason as a dependency in a Java 25 project)
Everything worked with the ConsoleHandler only, though, so I could trace it to the ConsoleGUI.
Moving the append() calls to the event thread has resolved the issue for me.